### PR TITLE
ci: only build Pages site/badges on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
         run: make report
 
       - name: Generate progress site and badges
+        if: github.event_name != 'pull_request'
         run: .venv/bin/python tools/generate_progress_site.py
         env:
           PAGES_BASE_URL: https://roengstrom.github.io/ff8-decomp


### PR DESCRIPTION
The progress report (build/report.json) still generates on PRs so decomp.dev can consume the uploaded artifact, but the Pages-only site assets and badges are skipped on PR runs.