### PR TITLE
world: decomp 22 functions across we_object1/2/4/6/10

### DIFF
--- a/config/undefined_syms.world.txt
+++ b/config/undefined_syms.world.txt
@@ -19,6 +19,7 @@ SetRotMatrix = 0x800406A4;
 SetTransMatrix = 0x80040734;
 RotMatrix = 0x80040FE4;
 SquareRoot0 = 0x8003F4A4;
+ratan2 = 0x80041E84;
 MulMatrix = 0x80040264;
 SetLightMatrix = 0x800406D4;
 SystemError = 0x800471E4;
@@ -36,6 +37,8 @@ CdGetSector = 0x8004397C;
 CdIntToPos = 0x80043A00;
 CdPosToInt = 0x80043B04;
 VSync = 0x80042634;
+MoveImage = 0x80048FBC;
+ClearImage = 0x80048DD4;
 
 /* Data blobs in bin section that are called/referenced by real code */
 func_800C4CA4 = 0x800C4CA4;

--- a/include/battle.h
+++ b/include/battle.h
@@ -665,7 +665,9 @@ extern BattleCharState g_battleChars;
 typedef struct {
     /* 0x0000 */ u8 pad0000[0x74];
     /* 0x0074 */ s32 colorTag;          /**< P_TAG consumed by renderBattleDisplayList. */
-    /* 0x0078 */ u8 pad0078[0x3FF4];
+    /* 0x0078 */ u8 pad0078[4];
+    /* 0x007C */ s32 otHead;            /**< P_TAG head — addPrim-style chain. */
+    /* 0x0080 */ u8 pad0080[0x3FEC];
 } BattleSceneCtx;
 
 extern BattleSceneCtx *D_800D244C;

--- a/include/common.h
+++ b/include/common.h
@@ -42,6 +42,11 @@ typedef union {
 /* Clamp value to [lo, hi] range. */
 #define CLAMP(val, lo, hi) ((val) < (lo) ? (lo) : (val) > (hi) ? (hi) : (val))
 
+/* Absolute value. Uses `<=` (rather than `<`) on the sign test so the
+ * compiler emits `blez` for the branch, matching the original codegen
+ * (`x == 0` falls into the negation arm, which still yields 0). */
+#define abs(x) ((x) <= 0 ? -(x) : (x))
+
 /*
  * Set/clear bit @c bitPos in a 64-bit flag set stored as @c u32 flags[2].
  * @c bitPos must be a signed type (s8 / s32) — this lets gcc 2.8.0 compile

--- a/include/sound.h
+++ b/include/sound.h
@@ -243,9 +243,10 @@ typedef struct {
  * by index and feed the result to @c sndSeqStartPan and friends.
  */
 typedef struct {
-    /* 0x00 */ u8 pad00[4];
-    /* 0x04 */ s32 field04;     /**< Sequence handle / ID. */
-    /* 0x08 */ u8 pad08[8];
+    /* 0x00 */ s32 bankHandle;  /**< Non-zero = bank-based playback (passed to sndPlayBankSfx). */
+    /* 0x04 */ s32 field04;     /**< Sequence handle / ID (also generic SFX arg 1). */
+    /* 0x08 */ s32 field08;     /**< Generic SFX arg 2 (vol). */
+    /* 0x0C */ s32 field0C;     /**< Generic SFX arg 3 (pan). */
     /* 0x10 */ s16 field10;     /**< Sequence track / priority. */
     /* 0x12 */ s16 field12;     /**< Sequence runtime state (cleared by stop helper). */
 } SeqEntry; /* 0x14 = 20 bytes */

--- a/src/world/we_object1.c
+++ b/src/world/we_object1.c
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "sound.h"
 #include "psxsdk/libapi.h"
+#include "psxsdk/libgpu.h"
 
 extern u8 D_800780D8[];
 extern u8 D_800C4DCC[];
@@ -17,7 +18,35 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_80099B48);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_80099C84);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_80099EDC);
+extern SeqEntry D_800C4FD8[];
+
+/**
+ * @brief Kick off the SFX for @c D_800C4FD8[idx] and mark it active.
+ *
+ * Dispatches on the entry's @c bankHandle:
+ *  - non-zero: @c sndPlayBankSfx(bankHandle, @c field04, @c field08,
+ *    @c field0C).
+ *  - zero:     @c sndPlaySfx(field10, @c field04, @c field08,
+ *    @c field0C).
+ *
+ * Then sets @c field12 = @c 1 to mark the entry as running.
+ *
+ * @param idx Index into @c D_800C4FD8.
+ */
+void func_80099EDC(s32 idx) {
+    if (D_800C4FD8[idx].bankHandle != 0) {
+        sndPlayBankSfx(D_800C4FD8[idx].bankHandle,
+                       D_800C4FD8[idx].field04,
+                       D_800C4FD8[idx].field08,
+                       D_800C4FD8[idx].field0C);
+    } else {
+        sndPlaySfx(D_800C4FD8[idx].field10,
+                   D_800C4FD8[idx].field04,
+                   D_800C4FD8[idx].field08,
+                   D_800C4FD8[idx].field0C);
+    }
+    D_800C4FD8[idx].field12 = 1;
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_80099F78);
 
@@ -51,7 +80,54 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_8009C1A4);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_8009C294);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_8009C478);
+/**
+ * @brief Two-stage @c LoadImage descriptor — pair of @c RECT / @c data
+ *        slots gated by the low nibble of @c flag. Shared between
+ *        @c func_8009C478 and @c func_8009C5FC.
+ */
+typedef struct {
+    RECT     rect1;
+    u32 *    data1;
+    RECT     rect2;
+    u32 *    data2;
+    u8       flag;
+} ImageDesc;
+
+extern void func_8009CA34(s32 *src, ImageDesc *desc);
+extern RECT D_800C8698;
+
+/**
+ * @brief Variant of @c func_8009C5FC that overrides the first
+ *        @c RECT's @c (x, y) with caller-supplied coordinates.
+ *
+ * Same two-stage @c LoadImage flow as @c func_8009C5FC, but the first
+ * blit's top-left corner is replaced by @p x, @p y (the @c w / @c h
+ * still come from the descriptor). The second blit (when bit 3 of
+ * @c desc.flag is set) uses @c desc.rect2 verbatim.
+ *
+ * Streams to the scratch @c D_800C8698 (separate from
+ * @c func_8009C5FC's @c D_800C8640).
+ *
+ * @param src Source buffer fed to @c func_8009CA34.
+ * @param x   Override X coordinate for the first blit.
+ * @param y   Override Y coordinate for the first blit.
+ */
+void func_8009C478(s32 *src, s32 x, s32 y) {
+    ImageDesc desc;
+    func_8009CA34(src, &desc);
+    D_800C8698.x = x;
+    D_800C8698.y = y;
+    D_800C8698.w = desc.rect1.w;
+    D_800C8698.h = desc.rect1.h;
+    LoadImage(&D_800C8698, desc.data1);
+    if ((desc.flag >> 3) & 1) {
+        D_800C8698.x = desc.rect2.x;
+        D_800C8698.y = desc.rect2.y;
+        D_800C8698.w = desc.rect2.w;
+        D_800C8698.h = desc.rect2.h;
+        LoadImage(&D_800C8698, desc.data2);
+    }
+}
 
 /**
  * @brief Fatal-error thunk that invokes the PSX SDK SystemError with category 0x57.
@@ -71,7 +147,42 @@ void func_8009C528(s32 rc) {
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_8009C54C);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object1", func_8009C5FC);
+extern RECT D_800C8640;
+
+/**
+ * @brief Pull a two-image descriptor from @p src and stream both TIMs
+ *        through @c LoadImage, gated by bit 3 of the descriptor flag.
+ *
+ * Steps:
+ *  1. @c func_8009CA34(@p src, @c &desc) — parse a streaming-image
+ *     header into @c desc.
+ *  2. Copy @c desc.rect1 into the scratch @c D_800C8640 and
+ *     @c LoadImage(@c &D_800C8640, @c desc.data1).
+ *  3. If bit 3 of @c desc.flag is set, copy @c desc.rect2 and
+ *     @c LoadImage the second payload too.
+ *
+ * The scratch @c D_800C8640 is re-used between both loads — the GPU
+ * blit is synchronous from this routine's POV, so the RECT can be
+ * overwritten right after the call returns.
+ *
+ * @param src Source buffer fed to @c func_8009CA34.
+ */
+void func_8009C5FC(s32 *src) {
+    ImageDesc desc;
+    func_8009CA34(src, &desc);
+    D_800C8640.x = desc.rect1.x;
+    D_800C8640.y = desc.rect1.y;
+    D_800C8640.w = desc.rect1.w;
+    D_800C8640.h = desc.rect1.h;
+    LoadImage(&D_800C8640, desc.data1);
+    if ((desc.flag >> 3) & 1) {
+        D_800C8640.x = desc.rect2.x;
+        D_800C8640.y = desc.rect2.y;
+        D_800C8640.w = desc.rect2.w;
+        D_800C8640.h = desc.rect2.h;
+        LoadImage(&D_800C8640, desc.data2);
+    }
+}
 
 extern void sndSeqSetTempoAlt(s32 tempo);
 extern void sndSetMasterVolume(s32 vol);

--- a/src/world/we_object10.c
+++ b/src/world/we_object10.c
@@ -5,10 +5,43 @@
 
 extern u8 D_800786D8;
 extern u8 D_800780D8[];
+extern u8 D_800DCE78[];
 extern SlotEntry D_800DBFB8[];
 extern s32 D_800C5B50;
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BD6EC);
+extern void func_800BAC84(u8 *p);
+extern s32 func_800BA870(u8 *p);
+
+extern s32 func_800B0010(void);
+
+/**
+ * @brief Search @c D_800DBFB8 for the slot whose @c marker matches the
+ *        value returned by @c func_800B0010.
+ *
+ * Calls @c func_800B0010 to get a marker byte, then linearly scans the
+ * first @c D_800C5B50 entries of @c D_800DBFB8 for the first slot whose
+ * @c marker matches. Returns the slot index or @c -1 if not found.
+ *
+ * Twin of @c func_800BD754 — same scan loop but the search key is
+ * sourced from @c func_800B0010 instead of an explicit argument.
+ *
+ * @return Matching slot index, or @c -1 on no match.
+ */
+s32 func_800BD6EC(void) {
+    s32 target = func_800B0010();
+    s32 i = 0;
+    s32 count = D_800C5B50;
+    if (count > 0) {
+        s32 bound = count;
+        SlotEntry *entry = &D_800DBFB8[0];
+        do {
+            if (target == entry->marker) return i;
+            i++;
+            entry++;
+        } while (i < bound);
+    }
+    return -1;
+}
 
 /**
  * @brief Linear search D_800DBFB8 for the first SlotEntry whose marker matches @p target.
@@ -115,7 +148,28 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BDA08);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BDA78);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BDAE4);
+/**
+ * @brief Classify @p pos against two band centres (@c 0x90 and @c 0x130)
+ *        within tolerance @p radius.
+ *
+ * Tests @p pos for proximity to each band centre:
+ *  - @c |pos @c - @c 0x130| @c < @c radius: returns @c 0.
+ *  - @c |pos @c - @c 0x90|  @c < @c radius: returns @c 1.
+ *  - otherwise:                              returns @c -1.
+ *
+ * @param pos     Position to classify.
+ * @param radius  Half-width tolerance for each band.
+ * @return Band index @c 0 or @c 1, or @c -1 if @p pos is outside both bands.
+ */
+s32 func_800BDAE4(s32 pos, s32 radius) {
+    s32 result = -1;
+    if (abs(pos - 0x130) < radius) {
+        result = 0;
+    } else if (abs(pos - 0x90) < radius) {
+        result = 1;
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BDB5C);
 
@@ -199,7 +253,30 @@ void func_800BE4D8(s32 *a, s32 *b, s32 t, s32 *out) {
     out[2] = b[2] + (val >> 12);
 }
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE578);
+extern s32 ratan2(s32 y, s32 x);
+
+/**
+ * @brief Convert a direction vector to (pitch, yaw, 0) Euler angles.
+ *
+ * Treats @p dir as a 3D direction (PSX y-down convention) and writes
+ * the equivalent rotation into @p out:
+ *  - @c out->vx (pitch) = @c ratan2(-vy, @c sqrt(vz*vz + vx*vx))
+ *  - @c out->vy (yaw)   = @c ratan2(vx, vz)
+ *  - @c out->vz         = @c 0
+ *
+ * Uses the PsyQ GTE helpers @c SquareRoot0 (integer sqrt) and
+ * @c ratan2 (returns an angle in the standard PSX 0x1000 = full-circle
+ * unit).
+ *
+ * @param dir Input direction vector.
+ * @param out Destination Euler angles (vz is cleared).
+ */
+void func_800BE578(SVECTOR *dir, SVECTOR *out) {
+    s32 horizDist = SquareRoot0(dir->vz * dir->vz + dir->vx * dir->vx);
+    out->vx = ratan2(-dir->vy, horizDist);
+    out->vy = ratan2(dir->vx, dir->vz);
+    out->vz = 0;
+}
 
 /** @brief 32-byte record used by func_800BE5F8's table walker. */
 typedef struct {
@@ -232,9 +309,88 @@ s32 func_800BE5F8(Record *rec) {
     return -2;
 }
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE63C);
+/**
+ * @brief Switch the @c D_800DCE78 subsystem between save and load modes.
+ *
+ * Dispatches based on @p reset:
+ *  - Non-zero @c reset: rebuild the @c D_800DCE78 state from scratch by
+ *    calling @c func_800BAC84 (init pass) followed by @c func_800BEFEC
+ *    (ramp/table fill). Returns @c 0.
+ *  - Zero @c reset: query @c func_800BA870 against the current state and
+ *    forward its return value.
+ *
+ * @param reset Non-zero rebuilds @c D_800DCE78; zero queries it instead.
+ * @return @c 0 in the rebuild path; @c func_800BA870's return value
+ *         otherwise.
+ */
+s32 func_800BE63C(s32 reset) {
+    s32 result = 0;
+    if (reset != 0) {
+        func_800BAC84(D_800DCE78);
+        func_800BEFEC(D_800DCE78);
+    } else {
+        result = func_800BA870(D_800DCE78);
+    }
+    return result;
+}
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE69C);
+/**
+ * @brief 0x34-byte transform entry — only the snapshot pair at @c 0x20
+ *        and @c 0x28 is mapped here. The trailing fields are consumed
+ *        by the per-entry handler @c func_800AEB58.
+ */
+typedef struct {
+    /* 0x00 */ u8 pad0[0x20];
+    /* 0x20 */ s32 prevWord;    /**< Snapshot of @c currWord, refreshed each tick. */
+    /* 0x24 */ s32 currWord;
+    /* 0x28 */ u16 prevHalf;    /**< Snapshot of @c currHalf. */
+    /* 0x2A */ u16 currHalf;
+    /* 0x2C */ u8 pad2C[0x8];
+} XformEntry; /* 0x34 */
+
+/**
+ * @brief Header for the transform-entry table walked by @c func_800BE69C.
+ *
+ * Only the @c count byte at @c 0x02 and the @c entries pointer at
+ * @c 0x18 are mapped — the surrounding padding holds fields used by
+ * other handlers in the same overlay.
+ */
+typedef struct {
+    /* 0x00 */ u8 pad0[2];
+    /* 0x02 */ s8 count;
+    /* 0x03 */ u8 pad3[0x15];
+    /* 0x18 */ XformEntry *entries;
+} XformGroup;
+
+extern void func_800AEB58(XformEntry *entry, XformGroup *group);
+
+/**
+ * @brief Snapshot each entry's @c curr fields into @c prev and invoke
+ *        the per-entry handler.
+ *
+ * Walks @p group->entries for @c group->count iterations. Before
+ * dispatching each entry to @c func_800AEB58:
+ *  - @c entry->prevHalf is loaded with @c entry->currHalf.
+ *  - @c entry->prevWord is loaded with @c entry->currWord.
+ *
+ * @c group->count is re-read each iteration since @c func_800AEB58 may
+ * mutate it (the cached @c i is compared against the fresh count).
+ *
+ * @param group Transform-entry group container.
+ */
+void func_800BE69C(XformGroup *group) {
+    XformEntry *entry = group->entries;
+    s32 i = 0;
+    if (group->count > 0) {
+        do {
+            i++;
+            entry->prevHalf = entry->currHalf;
+            entry->prevWord = entry->currWord;
+            func_800AEB58(entry, group);
+            entry++;
+        } while (i < group->count);
+    }
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE720);
 
@@ -242,7 +398,49 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE7FC);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE8B0);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BE958);
+extern u8 *D_800C9E34;
+extern ScriptOp *func_800AF004(u8 *base, s32 flag);
+
+/**
+ * @brief Walk the @c D_800C9E34 script and return the last
+ *        @c 0xFF15 opcode's @c param (when @c D_800C4D64->flag has
+ *        bit 3 set), else @c -1.
+ *
+ * Steps:
+ *  1. If @c D_800C4D64->flag bit 3 isn't set, returns @c -1.
+ *  2. Calls @c func_800AF004(@c D_800C9E34, 0) — if no script, returns
+ *     @c -1.
+ *  3. Walks the script, treating opcodes as:
+ *     - @c 0xFF05 (END): stop walking.
+ *     - @c 0xFF0E (JUMP): follow the @c param-relative jump.
+ *     - @c 0xFF15: snapshot the @c param into @c result.
+ *     - other: skip to next op.
+ *
+ * Returns the last @c 0xFF15 param seen, or @c -1 if none.
+ */
+s32 func_800BE958(void) {
+    s32 result = -1;
+    ScriptOp *p;
+
+    if (D_800C4D64->flag & 0x8) {
+        p = func_800AF004(D_800C9E34, 0);
+        if (p != 0) {
+            while (1) {
+                u16 op = p->op;
+                if (op == 0xFF05) break;
+                if (op == 0xFF0E) {
+                    p = (ScriptOp *)(D_800C9E34 + p->param);
+                    continue;
+                }
+                if (op == 0xFF15) {
+                    result = p->param;
+                }
+                p++;
+            }
+        }
+    }
+    return result;
+}
 
 extern void func_8009B358(s32 a0, s32 a1, s32 a2);
 extern void func_8009D8A8(s32 a0);
@@ -290,11 +488,109 @@ void func_800BEA34(void) {
     renderBattleDisplayList(&D_800D244C->colorTag);
 }
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BEA7C);
+extern s32 D_800C4D38;
+extern s32 D_800C5C1C;
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BEAF4);
+/**
+ * @brief Pick a per-map screen/mode constant keyed off @c D_800C4D38.
+ *
+ * Dispatches based on the current map id @c D_800C4D38:
+ *  - @c mapId @c < @c 0xA or @c == @c 0x80:
+ *      - @c D_800C5C1C @c > @c 0: returns @c 0x31.
+ *      - otherwise:               returns @c 0x20.
+ *  - @c mapId @c == @c 0x31:                          returns @c 0x20.
+ *  - @c mapId in @c [0x20, @c 0x29) or @c == @c 0x84: returns @c 0x32.
+ *  - @c mapId @c == @c 0x32:                          returns @c 0.
+ *  - otherwise:                                       returns @c -1.
+ *
+ * Constants look like screen-format / camera-mode selectors; the exact
+ * semantics aren't mapped yet.
+ *
+ * @return Per-map constant — @c 0x31, @c 0x32, @c 0x20, @c 0, or @c -1.
+ */
+s32 func_800BEA7C(void) {
+    s32 mapId = D_800C4D38;
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object10", func_800BEB84);
+    if ((u32)mapId < 0xA || mapId == 0x80) {
+        if (D_800C5C1C > 0) return 0x31;
+        return 0x20;
+    }
+    if (mapId == 0x31) return 0x20;
+    if ((u32)(mapId - 0x20) < 9 || mapId == 0x84) return 0x32;
+    if (mapId == 0x32) return 0;
+    return -1;
+}
+
+extern s32 D_800C5C18;
+extern s32 D_800C5C20;
+extern s32 D_800C5C24;
+extern s32 D_800C5C28;
+extern s32 D_800C5C2C;
+extern s32 D_800C5C30;
+
+/**
+ * @brief Check if @p val matches any of the 7 entries in the
+ *        @c D_800C5C18..D_800C5C30 slot table.
+ *
+ * Returns @c 0 immediately on negative @p val. Otherwise compares
+ * against each of the 7 named slot globals (@c D_800C5C18,
+ * @c D_800C5C1C, @c D_800C5C20, @c D_800C5C24, @c D_800C5C28,
+ * @c D_800C5C2C, @c D_800C5C30) and returns @c 1 on first match,
+ * @c 0 if none.
+ *
+ * @param val Slot identifier to test.
+ * @return @c 1 if @p val is in the slot table, @c 0 otherwise.
+ */
+s32 func_800BEAF4(s32 val) {
+    s32 result;
+    if (val < 0) return 0;
+    result = 0;
+    if (D_800C5C18 == val) result = 1;
+    else if (D_800C5C1C == val) result = 1;
+    else if (D_800C5C20 == val) result = 1;
+    else if (D_800C5C24 == val) result = 1;
+    else if (D_800C5C28 == val) result = 1;
+    else if (D_800C5C2C == val) result = 1;
+    else if (D_800C5C30 == val) result = 1;
+    return result;
+}
+
+/**
+ * @brief Compute a per-actor action code from the marker at
+ *        @c D_800D23D8[idx+2] crossed with the actor's @c flag1E.
+ *
+ * Looks up two pieces of per-actor state and combines them:
+ *  - marker = @c D_800D23D8[idx @c + @c 2] (byte from the world-state
+ *    flag buffer).
+ *  - flag = @c D_800DD6A8[idx].flag1E (s8 in the actor record).
+ *
+ * Returns:
+ *  - marker @c == @c 0 and flag @c == @c 1: @c 0x35.
+ *  - marker @c == @c 1 and flag @c == @c 1: @c 0x34.
+ *  - marker @c == @c 1 and flag @c == @c -1: @c 0x37.
+ *  - any other combination: @c -1.
+ *
+ * @param idx Actor index.
+ * @return Action code, or @c -1 if no rule matches.
+ */
+s32 func_800BEB84(s32 idx) {
+    s32 result = -1;
+    u8 marker = D_800D23D8[idx + 2];
+
+    if (marker == 0) {
+        if (D_800DD6A8[idx].flag1E == 1) {
+            result = 0x35;
+        }
+    } else if (marker == 1) {
+        s8 v = D_800DD6A8[idx].flag1E;
+        if (v == 1) {
+            result = 0x34;
+        } else if (v == -1) {
+            result = 0x37;
+        }
+    }
+    return result;
+}
 
 /**
  * @brief Map a command-kind code to a duration/timeout in frames.

--- a/src/world/we_object2.c
+++ b/src/world/we_object2.c
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "battle.h"
 #include "field.h"
 #include "sound.h"
 #include "world.h"
@@ -67,7 +68,48 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009CE70);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009CFB4);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009D0F0);
+extern s32 D_8005F138;
+
+extern void VSync(s32 mode);
+extern void func_800A5F78(s32 screen);
+extern void func_800A5FD4(s32 screen);
+
+/**
+ * @brief Vsync, scroll any partial display window back to origin, then
+ *        rebuild the screen-0 DRAWENV/DISPENV and clear the entity model.
+ *
+ * Steps:
+ *  1. @c VSync(0) — wait for vblank.
+ *  2. If @c (DISPENV*)D_8005F138->disp.x is non-zero, @c MoveImage
+ *     scrolls the live display rect back to @c (0,0) and a @c DrawSync
+ *     stalls until the move completes.
+ *  3. @c func_800A5F78(0) / @c func_800A5FD4(0) push the screen-0
+ *     DRAWENV and DISPENV.
+ *  4. @c ClearImage((RECT*)&D_800CA040, 0,0,0) blacks the entity-model
+ *     blob (the first 8 bytes of @ref D_800CA040 are interpreted as a
+ *     @c RECT here).
+ *  5. Final @c DrawSync(0) before returning.
+ *
+ * The unused @c DRAWENV / @c DISPENV locals match the original stack
+ * frame — they live on @c sp but are never written here (a leftover
+ * from the helper inlining the per-screen env setup once did).
+ */
+void func_8009D0F0(void) {
+    DRAWENV draw;
+    DISPENV disp;
+    DISPENV *env;
+
+    VSync(0);
+    env = (DISPENV *)D_8005F138;
+    if (env->disp.x != 0) {
+        MoveImage(&env->disp, 0, 0);
+        DrawSync(0);
+    }
+    func_800A5F78(0);
+    func_800A5FD4(0);
+    ClearImage(&D_800CA040, 0, 0, 0);
+    DrawSync(0);
+}
 
 extern SeqEntry D_800C4FD8[];
 extern void func_80099EDC(s32 idx);
@@ -159,7 +201,50 @@ void func_8009D630(void) {
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009D688);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009D760);
+/**
+ * @brief 4-byte slot (two halfwords). Default value is two @c -1s.
+ */
+typedef struct {
+    s16 a;
+    s16 b;
+} HalfwordPair;
+
+extern s32 func_800BD380(s16 *outLow, s16 *outHigh);
+extern s32 func_800BD2A0(s16 *outLow, s16 *outHigh);
+extern s32 func_800BD460(s16 *outLow, s16 *outHigh);
+
+/**
+ * @brief Fill three adjacent @ref HalfwordPair slots from three lookup
+ *        helpers, defaulting each slot to @c (-1, @c -1) on lookup miss.
+ *
+ * Walks @p s through three consecutive slots, calling one of three
+ * fetchers per slot:
+ *  - slot @c [0]: @c func_800BD380
+ *  - slot @c [1]: @c func_800BD2A0
+ *  - slot @c [2]: @c func_800BD460
+ *
+ * Each fetcher writes into @c (&s->a, @c &s->b) and returns non-zero on
+ * success. If it returns @c 0 (no entry available), the slot is filled
+ * with @c (-1, @c -1) — the "inactive" sentinel.
+ *
+ * @param s First slot of a three-slot array.
+ */
+void func_8009D760(HalfwordPair *s) {
+    if (func_800BD380(&s->a, &s->b) == 0) {
+        s->b = -1;
+        s->a = -1;
+    }
+    s++;
+    if (func_800BD2A0(&s->a, &s->b) == 0) {
+        s->b = -1;
+        s->a = -1;
+    }
+    s++;
+    if (func_800BD460(&s->a, &s->b) == 0) {
+        s->b = -1;
+        s->a = -1;
+    }
+}
 
 /** @brief Compare input against two entity IDs, return 0x29, 0x18, or -1. */
 s32 func_8009D7D8(s32 a0) {
@@ -227,9 +312,56 @@ void func_8009D8A8(s32 idx) {
     }
 }
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009D8F0);
+/**
+ * @brief Fade out every active SFX slot in @c D_800C526C and mark them inactive.
+ *
+ * Per-slot loop version of @c func_8009D8A8 — walks all 13 entries of
+ * @c D_800C526C, and for each slot whose @c field00 is not @c -1, writes
+ * @c -1 into @c field00 and calls @c fadeOutSfxSlow with the slot's
+ * @c field02 (SFX index). Used at world-map teardown to silence every
+ * field-engine-owned SFX channel in one pass.
+ */
+void func_8009D8F0(void) {
+    s32 i;
+    for (i = 0; i < 13; i++) {
+        s32 field00 = D_800C526C[i].field00;
+        s32 field02 = D_800C526C[i].field02;
+        if (field00 != -1) {
+            D_800C526C[i].field00 = -1;
+            fadeOutSfxSlow(field02);
+        }
+    }
+}
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009D954);
+extern BattleSceneCtx *D_800D244C;
+extern void fadeOutSfxFast(s32 idx);
+extern void renderAndUpdateDisplay(s32 frameCount);
+extern s32 renderBattleDisplayList(s32 *colorTag);
+
+/**
+ * @brief Hard tear-down: fade every @c D_800C526C SFX slot fast, then push
+ *        a 2-frame display flush.
+ *
+ * Walks all 13 entries of @c D_800C526C and unconditionally marks each
+ * @c field00 inactive (@c -1) and calls @c fadeOutSfxFast on its
+ * @c field02 — the harder/faster sibling of @c func_8009D8F0, which
+ * only acts on already-active slots. Then pushes @c 2 frames via
+ * @c renderAndUpdateDisplay and flushes the battle scene's
+ * @c colorTag into the display list.
+ *
+ * Used at world/battle hand-off when an immediate audio cut and frame
+ * push are required.
+ */
+void func_8009D954(void) {
+    s32 i;
+    for (i = 0; i < 13; i++) {
+        s32 sfxIdx = D_800C526C[i].field02;
+        D_800C526C[i].field00 = -1;
+        fadeOutSfxFast(sfxIdx);
+    }
+    renderAndUpdateDisplay(2);
+    renderBattleDisplayList(&D_800D244C->colorTag);
+}
 
 extern s32 getSfxField28(s32 idx);
 
@@ -405,7 +537,7 @@ void func_8009FE80(SVECTOR *a0, MATRIX *a1) {
     SetLightMatrix(&m);
 }
 
-extern void func_800A017C(s32 *vec);
+extern s32 func_800A017C(SVECTOR *v);
 
 /**
  * @brief Forward @p vec to func_800A017C, ignoring the first arg register.
@@ -415,7 +547,7 @@ extern void func_800A017C(s32 *vec);
  * @param unused First arg register, ignored.
  * @param vec Pointer forwarded as the first arg of func_800A017C.
  */
-void func_8009FEBC(s32 unused, s32 *vec) {
+void func_8009FEBC(s32 unused, SVECTOR *vec) {
     func_800A017C(vec);
 }
 
@@ -434,11 +566,81 @@ void func_8009FEDC(u8 *a0, u8 a1) {
     a0[0xA] = a1;
 }
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009FF0C);
+/**
+ * @brief Pick an audio/parameter constant from a map-ID + mode pair.
+ *
+ * Special-cased @p mapId values return @c 0x400. The set is the union of
+ * the ranges @c [0x20, 0x29), @c [0x10, 0x17), @c [0x40, 0x43) and the
+ * singletons @c 0x30, @c 0x32, @c 0x84. For non-special @p mapId values,
+ * the result is selected by @p mode:
+ *  - @p mode == 0: @c 0x400
+ *  - @p mode == 1: @c 0x280
+ *  - otherwise:    @c 1
+ *
+ * The exact semantics are uncertain; the constants look like sound /
+ * fade-time parameters keyed off the world-map area.
+ *
+ * @param mapId World-map area identifier.
+ * @param mode  Mode selector consulted only on non-special @p mapId.
+ * @return Selected constant — @c 0x400, @c 0x280, or @c 1.
+ */
+s32 func_8009FF0C(s32 mapId, s32 mode) {
+    if ((u32)(mapId - 0x20) < 9 ||
+        mapId == 0x84 ||
+        mapId == 0x30 ||
+        (u32)(mapId - 0x10) < 7 ||
+        (u32)(mapId - 0x40) < 3 ||
+        mapId == 0x32 ||
+        mode == 0) {
+        return 0x400;
+    }
+    return mode == 1 ? 0x280 : 1;
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_8009FF70);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_800A0000);
+extern s16 D_800C534C;
+extern s16 D_800C5344;
+
+/**
+ * @brief Pick a per-map screen-scroll offset, with special handling for
+ *        @c mapId @c == @c 0x32 and a @p mode-keyed fallback.
+ *
+ * Returns @c D_800C534C for the "common" map set:
+ *  - @c mapId in @c [0x20, @c 0x29),
+ *  - @c mapId @c == @c 0x84,
+ *  - @c mapId @c == @c 0x30,
+ *  - @c mapId in @c [0x10, @c 0x17),
+ *  - @c mapId in @c [0x40, @c 0x43).
+ *
+ * For @c mapId @c == @c 0x32 returns @c -scroll @c / @c 24 @c - @c 0x100
+ * — a scroll-based offset computed from @p scroll.
+ *
+ * Otherwise selects on @p mode:
+ *  - @c mode @c == @c 0: @c D_800C534C.
+ *  - @c mode @c == @c 1: @c D_800C5344.
+ *  - else:               @c 1.
+ *
+ * @param mapId  World-map area identifier.
+ * @param mode   Mode selector consulted only on non-special @p mapId.
+ * @param scroll Scroll value, only used for @p mapId @c == @c 0x32.
+ * @return Selected scroll offset.
+ */
+s32 func_800A0000(s32 mapId, s32 mode, s32 scroll) {
+    if ((u32)(mapId - 0x20) < 9 ||
+        mapId == 0x84 ||
+        mapId == 0x30 ||
+        (u32)(mapId - 0x10) < 7 ||
+        (u32)(mapId - 0x40) < 3) {
+        return D_800C534C;
+    }
+    if (mapId == 0x32) {
+        return -scroll / 24 - 0x100;
+    }
+    if (mode == 0) return D_800C534C;
+    if (mode == 1) return D_800C5344;
+    return 1;
+}
 
 /** Returns a value based on input comparison. */
 s32 func_800A009C(s32 val) {
@@ -450,4 +652,38 @@ s32 func_800A009C(s32 val) {
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_800A00B4);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object2", func_800A017C);
+/**
+ * @brief Wrap @c vx into @c [0, 0x7FF] and @c vz into @c [-0x7FF, 0] by ±0x800.
+ *
+ * Used by the world map system to keep coordinates inside the active tile —
+ * when a coordinate spills past the tile boundary, it is shifted by one
+ * tile (0x800) so subsequent computations stay in-range.
+ *
+ *  - @c vx (offset 0): clamp to @c [0, 0x7FF]. If @c vx >= 0x800 subtract
+ *    0x800; if @c vx < 0 add 0x800.
+ *  - @c vz (offset 4): clamp to @c [-0x7FF, 0]. If @c vz > 0 subtract
+ *    0x800; if @c vz <= -0x800 add 0x800.
+ *
+ * @c vy (offset 2) and @c pad (offset 6) are left alone.
+ *
+ * @param v Target vector.
+ * @return @c 1 if either component was shifted, else @c 0.
+ */
+s32 func_800A017C(SVECTOR *v) {
+    s32 changed = 0;
+    if (v->vx >= 0x800) {
+        v->vx -= 0x800;
+        changed = 1;
+    } else if (v->vx < 0) {
+        v->vx += 0x800;
+        changed = 1;
+    }
+    if (v->vz > 0) {
+        v->vz -= 0x800;
+        changed = 1;
+    } else if (v->vz <= -0x800) {
+        v->vz += 0x800;
+        changed = 1;
+    }
+    return changed;
+}

--- a/src/world/we_object4.c
+++ b/src/world/we_object4.c
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "battle.h"
 #include "psxsdk/libgpu.h"
 #include "world.h"
 
@@ -76,7 +77,41 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A8A28);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A8C1C);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A9254);
+extern u8 D_800D9CB0[];
+extern POLY_FT4 D_800D88B0[2][64];
+extern TILE D_800DA8D0[2][64];
+
+/**
+ * @brief Initialise three world-render pools in one go:
+ *
+ *  1. Clear bytes @c 0x28 and @c 0x29 of every 0x30-stride entry in
+ *     the @c D_800D9CB0 pool (size @c 0xC00 bytes ⇒ 64 entries).
+ *  2. Prime each @c POLY_FT4 in @c D_800D88B0[2][64] with
+ *     @c len = @c 9 and @c code = @c 0x2C.
+ *  3. Prime each @c TILE in @c D_800DA8D0[2][64] with
+ *     @c len = @c 3 and @c code = @c 0x60.
+ *
+ * Used at world setup time to prepare the per-frame prim templates.
+ */
+void func_800A9254(void) {
+    u8 *p = D_800D9CB0;
+    s32 j, i;
+
+    while (p < &D_800D9CB0[0xC00]) {
+        p[0x28] = 0;
+        p[0x29] = 0;
+        p += 0x30;
+    }
+
+    for (j = 0; j < 2; j++) {
+        for (i = 0; i < 64; i++) {
+            setlen(&D_800D88B0[j][i], 9);
+            setcode(&D_800D88B0[j][i], 0x2C);
+            setlen(&D_800DA8D0[j][i], 3);
+            setcode(&D_800DA8D0[j][i], 0x60);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A9300);
 
@@ -84,7 +119,41 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A9CC0);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A9E24);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A9ED4);
+extern POLY_GT4 D_800D5A00[2][64];
+extern POLY_GT3 D_800D7400[2][64];
+
+/**
+ * @brief Initialise two double-buffered prim pools with their tag headers.
+ *
+ * For each of the two pools at @c D_800D5A00[0..1] (POLY_GT4) and
+ * @c D_800D7400[0..1] (POLY_GT3), walks all 64 slots and primes each
+ * primitive's header:
+ *  - @c POLY_GT4: @c len = @c 0xC (12 words), @c code = @c 0x3C.
+ *  - @c POLY_GT3: @c len = @c 0x9 (9 words),  @c code = @c 0x34.
+ *
+ * Used to prime the prim templates before per-frame GPU command
+ * generation fills in the colour/uv/xy fields.
+ *
+ * The @c p4 / @c p3 pointer locals shadow the array-index expressions
+ * to force the right per-iteration register layout (a leftover idiom
+ * from the original — without the locals the compiler hoists the
+ * @c 0xC constant outside the inner loop, which doesn't match).
+ */
+void func_800A9ED4(void) {
+    POLY_GT4 *p4;
+    POLY_GT3 *p3;
+    s32 j, i;
+    for (j = 0; j < 2; j++) {
+        for (i = 0; i < 64; i++) {
+            p4 = &D_800D5A00[j][i];
+            p3 = &D_800D7400[j][i];
+            setlen(&D_800D5A00[j][i], 0xC);
+            setcode(&D_800D5A00[j][i], 0x3C);
+            setlen(&D_800D7400[j][i], 0x9);
+            setcode(&D_800D7400[j][i], 0x34);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800A9F54);
 
@@ -102,7 +171,46 @@ INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800AAF84);
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800AAFBC);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800AB02C);
+/**
+ * @brief 0x1C-byte prim link — first word is an addPrim-style P_TAG, the
+ *        @c prim_len halfword at @c 0x1A is set to @c 0xC by the inserter.
+ */
+typedef struct {
+    /* 0x00 */ s32 link;
+    /* 0x04 */ u8 pad04[0x16];
+    /* 0x1A */ s16 prim_len;
+} PrimLink;
+
+/**
+ * @brief Set @p p's length to @c 0xC and splice it onto the
+ *        @c D_800D244C->otHead chain using @p maskTake / @p maskKeep
+ *        bit-merge masks.
+ *
+ * The two masks select which bit-groups of the link words come from
+ * the old chain vs the new node — calling with
+ * @p maskTake = @c 0x00FFFFFF and @p maskKeep = @c 0xFF000000 yields
+ * the standard PsyQ @c addPrim semantics (preserve the high tag byte,
+ * overwrite the low-24 next pointer).
+ *
+ * @param p         New node to splice in. Its @c prim_len is reset to
+ *                  @c 0xC and its @c link receives the previous
+ *                  @c otHead bits selected by @p maskTake.
+ * @param unused    Ignored.
+ * @param maskTake  Bit-mask selecting the "new value" bits.
+ * @param maskKeep  Bit-mask selecting the "old value" bits.
+ * @return Updated @c otHead value (also written into the chain).
+ */
+s32 func_800AB02C(PrimLink *p, s32 unused, s32 maskTake, s32 maskKeep) {
+    BattleSceneCtx *ctx;
+    s32 result;
+
+    p->prim_len = 0xC;
+    ctx = D_800D244C;
+    p->link = (p->link & maskKeep) | (ctx->otHead & maskTake);
+    result = (ctx->otHead & maskKeep) | ((s32)p & maskTake);
+    ctx->otHead = result;
+    return result;
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object4", func_800AB06C);
 

--- a/src/world/we_object6.c
+++ b/src/world/we_object6.c
@@ -1,9 +1,80 @@
 #include "common.h"
 #include "world.h"
 
+/**
+ * @brief 8-byte world-transform block — four packed halfwords.
+ *
+ * Layout inferred from cross-overlay halfword accesses to @c D_800D2390
+ * in @c we_object2/4/6/7 — every field is read/written as @c lh / @c sh
+ * at a fixed offset. Only @c angle has a semantically identified role
+ * (it's the input to the rotation helper @c func_800A00B4); the
+ * @c unkN slots are placeholders for fields whose purpose is not yet
+ * mapped.
+ */
+typedef struct {
+    /* 0x00 */ s16 unk0;
+    /* 0x02 */ s16 angle;
+    /* 0x04 */ s16 unk4;
+    /* 0x06 */ s16 unk6;
+} WorldXformBlock; /* 0x08 */
+
+/**
+ * @brief 16-byte world-transform record at @c D_800D2390.
+ *
+ * Pair of @ref WorldXformBlock entries — @c head occupies the first 8
+ * bytes and @c tail the last 8. @c func_800ACD38 snapshots @c tail,
+ * adjusts its @c angle, and forwards the modified copy to
+ * @c func_800ACC68.
+ */
+typedef struct {
+    /* 0x00 */ WorldXformBlock head;
+    /* 0x08 */ WorldXformBlock tail;
+} WorldXform; /* 0x10 */
+
+extern s16 D_800C977A;
+extern u8 D_800C97F8[];
+extern WorldXform D_800D2390;
+
+extern s32 func_800A00B4(s32 a, s32 b);
+extern void *memcpy(void *dst, const void *src, u32 n);
+
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object6", func_800ACC68);
 
-INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object6", func_800ACD38);
+extern void func_800ACC68(s32 a, WorldXformBlock *buf, u8 *p1, WorldXform *xform);
+
+/**
+ * @brief Snapshot @c D_800D2390.tail with an angle-adjusted @c angle
+ *        halfword, then forward to @c func_800ACC68.
+ *
+ * Steps:
+ *  1. Compute @c delta = @c func_800A00B4(@c D_800C977A,
+ *     @c D_800D2390.tail.angle) @c >> @c 1 — half the signed result.
+ *  2. Snapshot @c D_800D2390.tail into a local @ref WorldXformBlock via
+ *     @c memcpy. The source is cast to @c (u8 @c *) so the compiler
+ *     emits @c lwl / @c lwr (matching the target's byte-granular 8-byte
+ *     copy).
+ *  3. Add @c delta to the @c angle of the local copy.
+ *  4. Forward @c (arg, @c &buf, @c D_800C97F8, @c &D_800D2390) to
+ *     @c func_800ACC68.
+ *
+ * @note Purpose uncertain — appears to apply an angle correction to a
+ *       cached transform/rotation payload before dispatching world-render
+ *       work.
+ *
+ * @param arg First arg forwarded verbatim to @c func_800ACC68.
+ */
+void func_800ACD38(s32 arg) {
+    WorldXformBlock buf;
+    s32 delta;
+
+    delta = func_800A00B4(D_800C977A, D_800D2390.tail.angle) >> 1;
+
+    memcpy(&buf, (u8 *)&D_800D2390.tail, sizeof(buf));
+
+    buf.angle += delta;
+
+    func_800ACC68(arg, &buf, D_800C97F8, &D_800D2390);
+}
 
 INCLUDE_ASM("asm/ovl/world/nonmatchings/we_object6", func_800ACDC4);
 


### PR DESCRIPTION
we_object1:
  - func_80099EDC: kick off SeqEntry SFX (bank or direct)
  - func_8009C478: LoadImage two-stage with (x,y) override
  - func_8009C5FC: two-stage LoadImage from ImageDesc

we_object2:
  - func_800A017C: wrap world-map vx/vz into tile range
  - func_8009D8F0: fade-out every active SfxSlot
  - func_8009FF0C: map-id+mode parameter selector
  - func_8009D0F0: VSync, re-home display rect, clear bg
  - func_8009D760: three-slot fetch with fallback sentinel
  - func_8009D954: hard SFX tear-down + frame flush
  - func_800A0000: per-map scroll offset with 0x32 special

we_object4:
  - func_800A9ED4: prime two double-buffered prim pools
  - func_800AB02C: splice prim into D_800D244C otHead chain
  - func_800A9254: init 3 world-render pools (clear, FT4, TILE)

we_object6:
  - func_800ACD38: D_800D2390 angle-adjust payload forward

we_object10:
  - func_800BE63C: D_800DCE78 rebuild-or-query dispatch
  - func_800BE69C: snapshot+dispatch XformEntry table
  - func_800BE578: direction vector to Euler angles (atan2 + SquareRoot0)
  - func_800BEA7C: per-map screen-mode constant selector
  - func_800BDAE4: classify pos against two band centres (uses abs)
  - func_800BD6EC: marker-search from func_800B0010
  - func_800BEAF4: slot-table contains check
  - func_800BEB84: per-actor action code lookup
  - func_800BE958: read last 0xFF15 param from cmd script

Headers / types:
  - common.h: add abs(x) macro (uses <= for blez codegen match)
  - battle.h: add BattleSceneCtx.otHead at +0x7C
  - sound.h: name SeqEntry's s32 fields at +0x00/08/0C
  - undefined_syms.world.txt: expose SquareRoot0/ratan2/MoveImage/ClearImage