### PR TITLE
Decompile small sound command and bank helpers

### DIFF
--- a/src/snd_bank.c
+++ b/src/snd_bank.c
@@ -9,6 +9,7 @@ extern s32 D_80074EB0;
 extern VoicePoolEntry D_80074F20[12];
 extern u16 D_80074FE4;
 extern s32 D_80075078;
+extern s32 D_80075028[];
 
 /**
  * @brief Adjusts instrument index upward if flag 0x400 is set and instrument is in range.
@@ -201,9 +202,49 @@ INCLUDE_ASM("asm/nonmatchings/snd_bank", func_80017AAC);
  */
 INCLUDE_ASM("asm/nonmatchings/snd_bank", func_80017C9C);
 
-INCLUDE_ASM("asm/nonmatchings/snd_bank", func_80017D14);
+void func_80017D14(SoundSeqTrack *seq, s32 *tracks) {
+    s32 value = seq->instParams;
+    s32 mask;
+    s32 bit;
+    s32 *flags;
 
-INCLUDE_ASM("asm/nonmatchings/snd_bank", func_80017D5C);
+    if (value != 0) {
+        mask = value;
+        bit = 1;
+        flags = (s32 *)((s32)tracks + 0xF8);
+        do {
+            if (mask & bit) {
+                mask ^= bit;
+                *flags |= 3;
+            }
+            flags = (s32 *)((s32)flags + 0x110);
+            bit <<= 1;
+        } while (mask != 0);
+    }
+}
+
+void func_80017D5C(void) {
+    s32 value = D_80075028[0];
+    s32 mask;
+    s32 bit;
+    SoundSeqTrack *tracks;
+    s32 *flags;
+
+    if (value != 0) {
+        mask = value;
+        bit = 0x1000;
+        tracks = D_80072F70;
+        flags = (s32 *)((s32)tracks + 0xF8);
+        do {
+            if (mask & bit) {
+                mask ^= bit;
+                *flags |= 3;
+            }
+            flags = (s32 *)((s32)flags + 0x110);
+            bit <<= 1;
+        } while (mask != 0);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/snd_bank", func_80017DB0);
 

--- a/src/snd_cmd.c
+++ b/src/snd_cmd.c
@@ -96,7 +96,13 @@ void sndVoiceCmdSetVolume(SndVoice *voice, s32 volume) {
  *
  * @param voice Pointer to the voice control structure.
  */
-INCLUDE_ASM("asm/nonmatchings/snd_cmd", func_8003BC0C);
+void func_8003BC0C(SndVoice *voice) {
+    voice->cmdType = 0x4B;
+    voice->cmdDataPtr = 0;
+    voice->cmdSize = 0;
+}
+/* Preserve padding before func_8003BC24. */
+asm("nop");
 
 INCLUDE_ASM("asm/nonmatchings/snd_cmd", func_8003BC24);
 INCLUDE_ASM("asm/nonmatchings/snd_cmd", func_8003BD84);


### PR DESCRIPTION
Decompiles three matching sound helpers:

- `func_8003BC0C`
- `func_80017D14`
- `func_80017D5C`

`func_8003BC0C` keeps the original padding before `func_8003BC24` so following symbol addresses stay unchanged.

Verified with Docker:

```text
built=40706b4e0553fc6cbeb044ca1e0e9004d5ac2561
orig=40706b4e0553fc6cbeb044ca1e0e9004d5ac2561
```