### PR TITLE
refactor / clean up cdrom.c

### DIFF
--- a/include/cd.h
+++ b/include/cd.h
@@ -23,11 +23,11 @@ typedef struct {
     /* 0x00 */ u32 timeout;       /**< Timeout counter (resets at 0x708 / 1800). */
     /* 0x04 */ u32 readSectors;   /**< Number of sectors for current read. */
     /* 0x08 */ u16 state;         /**< CD drive state machine phase. */
-    /* 0x0A */ u16 discNumber;    /**< Disc number (set by setDiscNumber). */
+    /* 0x0A */ s16 discNumber;    /**< Disc number, 1..4 or -1 (write-only; set by setDiscNumber). */
     /* 0x0C */ u8 pad0C[4];
     /* 0x10 */ u8 busyFlag;       /**< CD busy flag (setCdBusyFlag/clearCdBusyFlag). */
     /* 0x11 */ u8 cdState;        /**< CD state byte (getCdState/resetCdDriveMode). */
-    /* 0x12 */ u8 discId;         /**< Disc ID (getDiscId). */
+    /* 0x12 */ s8 discId;         /**< Disc ID (read signed by getDiscId). */
     /* 0x13 */ u8 pad13;
 } CdDriveState; /* 0x14 = 20 bytes */
 
@@ -51,6 +51,12 @@ typedef struct {
 
 /** @brief Async CD read state owned by @c cdread.c; polled by @c func_800393C8. */
 extern CdReadState D_8008A3D8;
+
+/* Shared CD driver state / buffers (used by both cdrom.c and cdread.c). */
+extern CdDriveState D_8008A3C8; /**< CD drive timeout / state machine. */
+extern u8  D_8008A3DC[];        /**< CD command parameter buffer (aliases @c D_8008A3D8.params). */
+extern s32 D_8008A3B8;          /**< Rolling read-cursor LBA (set by @c func_80038868). */
+extern u8  D_800853B8[];        /**< CD read staging buffer. */
 
 extern s32 cdReadAsyncSync(s32 lba, u32 size, u8 *dest, void (*callback)(void));
 

--- a/include/cd.h
+++ b/include/cd.h
@@ -2,6 +2,7 @@
 #define CD_H
 
 #include "common.h"
+#include "psxsdk/libcd.h"
 
 /** @brief CD-ROM file descriptor (sector + size pair).
  *
@@ -42,7 +43,8 @@ typedef struct {
     /* 0x01 */ u8 status;          /**< State machine phase (0=idle, 0xB=complete, 0xC=reset). */
     /* 0x02 */ u8 discNum;         /**< Detected disc number (aliases @c D_8008A3DA / @ref getDiscId). */
     /* 0x03 */ u8 pad03;
-    /* 0x04 */ u8 params[4];       /**< CdControl parameters. */
+    /* 0x04 */ CdlLOC params;      /**< Seek location filled by CdIntToPos; cast to
+                                    *   @c u8* when passed to CdControl. */
     /* 0x08 */ u32 sectorCount;    /**< Number of sectors to read. */
     /* 0x0C */ u8 pad0C[0x10];
     /* 0x1C */ u8 *readBuffer;     /**< Destination buffer for CdRead. */

--- a/include/cdread.h
+++ b/include/cdread.h
@@ -1,0 +1,16 @@
+#ifndef CDREAD_H
+#define CDREAD_H
+
+#include "common.h"
+
+// CD read/seek state-machine handlers (cdread.c), invoked directly and through
+// the D_800562D8 dispatch table before their definitions appear.
+
+void cdPollReadState(void);
+void cdReadSectors(void);
+void cdHandleReadSync(void);
+void cdPollSeekState(void);
+void func_80039140(void);
+void func_80039218(void);
+
+#endif /* CDREAD_H */

--- a/include/cdrom.h
+++ b/include/cdrom.h
@@ -3,7 +3,7 @@
 
 #include "common.h"
 
-// Public prototypes (owned by cdrom.c)
+// Public prototypes
 
 /** @brief Initialize the CD subsystem. */
 void initCdSubsystem(s32 mode);
@@ -18,7 +18,7 @@ s32 func_80038A60(void);
 /** @brief Record the active disc number in the drive state. */
 void setDiscNumber(s32 discNumber);
 
-// Private prototypes (internal to cdrom.c
+// Private prototypes
 
 s32 detectDiscNumber(void);
 void setAudioVolume(s32 voice);
@@ -31,15 +31,11 @@ s32 cdReadRetry(s32 lba, void (*callback)(void));
 u32 getCdState(void);
 void stopCdDrive(void);
 
-// Private data (internal to cdrom.c
+// Private data
 
-extern u8 D_8001092C[]; /**< Disc-1 identifier filename (searched by detectDiscNumber). */
+extern u8 D_8001092C[]; /**< Disc-1 identifier filename. */
 extern u8 D_8001093C[]; /**< Disc-2 identifier filename. */
 extern u8 D_8001094C[]; /**< Disc-3 identifier filename. */
 extern u8 D_8001095C[]; /**< Disc-4 identifier filename. */
-
-/* The former standalone symbols D_8008A3D0 / D_8008A3D2 / D_8008A3D9 /
-   D_8008A3DA are fields of the CdDriveState at D_8008A3C8 (cd.h): state,
-   discNumber, cdState and discId respectively. */
 
 #endif /* CDROM_H */

--- a/include/cdrom.h
+++ b/include/cdrom.h
@@ -3,7 +3,43 @@
 
 #include "common.h"
 
-/** @brief Initialize the CD subsystem (owned by cdrom.c). */
+// Public prototypes (owned by cdrom.c)
+
+/** @brief Initialize the CD subsystem. */
 void initCdSubsystem(s32 mode);
+/** @brief Perform a synchronous (blocking) CD-ROM read. */
+s32 cdReadSync(s32 lba, u32 size, u8 *dest, void (*callback)(void));
+/** @brief Reset CD state unless already idle or in its final state. */
+void resetCdDrive(void);
+/** @brief Reset the CD drive mode (double-speed) and clear the state byte. */
+void resetCdDriveMode(void);
+/** @brief Verify the inserted disc and report a status code. */
+s32 func_80038A60(void);
+/** @brief Record the active disc number in the drive state. */
+void setDiscNumber(s32 discNumber);
+
+// Private prototypes (internal to cdrom.c
+
+s32 detectDiscNumber(void);
+void setAudioVolume(s32 voice);
+void clearCdBusyFlag(void);
+void setCdBusyFlag(void);
+void flushCdAndWait(void);
+void func_80038760(s32 mode, s32 lba, u32 size, u8 *dest, void (*callback)(void));
+s32 func_800387F8(s32 lba, void (*callback)(void));
+s32 cdReadRetry(s32 lba, void (*callback)(void));
+u32 getCdState(void);
+void stopCdDrive(void);
+
+// Private data (internal to cdrom.c
+
+extern u8 D_8001092C[]; /**< Disc-1 identifier filename (searched by detectDiscNumber). */
+extern u8 D_8001093C[]; /**< Disc-2 identifier filename. */
+extern u8 D_8001094C[]; /**< Disc-3 identifier filename. */
+extern u8 D_8001095C[]; /**< Disc-4 identifier filename. */
+
+/* The former standalone symbols D_8008A3D0 / D_8008A3D2 / D_8008A3D9 /
+   D_8008A3DA are fields of the CdDriveState at D_8008A3C8 (cd.h): state,
+   discNumber, cdState and discId respectively. */
 
 #endif /* CDROM_H */

--- a/include/intro.h
+++ b/include/intro.h
@@ -80,9 +80,8 @@ extern s32  func_8004D174(void);
 extern s32  func_8004D208(s32 a);
 extern void func_800275D4();          /* K&R prototype, intentional. */
 extern s32  func_800393C8(void);
-extern void resetCdDriveMode(void);
 extern s32  getDiscId(void);
-extern s32  func_80038A60(void);
+/* resetCdDriveMode / func_80038A60 are declared by their owner, cdrom.h. */
 extern s32  getAnimFrameParam(s32 slot, s32 sub);
 
 #endif /* INTRO_H */

--- a/include/intro.h
+++ b/include/intro.h
@@ -81,7 +81,6 @@ extern s32  func_8004D208(s32 a);
 extern void func_800275D4();          /* K&R prototype, intentional. */
 extern s32  func_800393C8(void);
 extern s32  getDiscId(void);
-/* resetCdDriveMode / func_80038A60 are declared by their owner, cdrom.h. */
 extern s32  getAnimFrameParam(s32 slot, s32 sub);
 
 #endif /* INTRO_H */

--- a/include/psxsdk/libcd.h
+++ b/include/psxsdk/libcd.h
@@ -30,7 +30,7 @@ s32 CdControlF(u8 com, u8 *param);
 void CdMix(CdlATV *vol);
 s32 CdGetSector(void *madr, s32 size);
 s32 CdPosToInt(CdlLOC *p);
-void CdIntToPos(s32 i, CdlLOC *p);
+CdlLOC *CdIntToPos(s32 i, CdlLOC *p);
 CdlCB CdSyncCallback(CdlCB func);
 CdlCB CdReadyCallback(CdlCB func);
 s32 CdSync(s32 mode, u8 *result);

--- a/include/snd_cd.h
+++ b/include/snd_cd.h
@@ -1,0 +1,11 @@
+#ifndef SND_CD_H
+#define SND_CD_H
+
+#include "common.h"
+
+// Public prototypes
+
+/** @brief LZSS-decompress @p src into @p dest (owned by snd_cd.c). */
+s32 func_80039444(u8 *src, u8 *dest);
+
+#endif /* SND_CD_H */

--- a/include/snd_cd.h
+++ b/include/snd_cd.h
@@ -5,7 +5,7 @@
 
 // Public prototypes
 
-/** @brief LZSS-decompress @p src into @p dest (owned by snd_cd.c). */
+/** @brief LZSS-decompress @p src into @p dest. */
 s32 func_80039444(u8 *src, u8 *dest);
 
 #endif /* SND_CD_H */

--- a/src/cdread.c
+++ b/src/cdread.c
@@ -4,6 +4,7 @@
 #include "overlay.h"
 #include "sound.h"
 #include "cd.h"
+#include "cdread.h"
 
 /* D_8008A3C8 / D_8008A3B8 / D_8008A3DC / D_800853B8 come from cd.h. */
 extern u8 *D_80039418;

--- a/src/cdread.c
+++ b/src/cdread.c
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "psxsdk/libgpu.h"
+#include "psxsdk/libcd.h"
 #include "overlay.h"
 #include "sound.h"
 #include "cd.h"
@@ -41,7 +42,7 @@ void cdStartSyncRead(void) {
     s32 result = CdSync(1, 0);
 
     if (result == 2) {
-        CdControl(2, D_8008A3D8.params, 0);
+        CdControl(2, (u8 *)&D_8008A3D8.params, 0);
         D_8008A3D8.status = 1;
         cdClearStatusAndCallback();
     }
@@ -59,7 +60,7 @@ void cdStartAsyncRead(void) {
     s32 result = CdSync(1, 0);
 
     if (result == 2) {
-        CdControlF(2, D_8008A3D8.params);
+        CdControlF(2, (u8 *)&D_8008A3D8.params);
         D_8008A3D8.status = 4;
         cdPollReadState();
     }
@@ -168,7 +169,7 @@ void cdStartAsyncSeek(void) {
     s32 result = CdSync(1, 0);
 
     if (result == 2) {
-        CdControlF(2, D_8008A3D8.params);
+        CdControlF(2, (u8 *)&D_8008A3D8.params);
         D_8008A3D8.status = 8;
         cdPollSeekState();
     }
@@ -263,7 +264,7 @@ void func_80039218(void) {
             D_8008A3D8.status = 1;
             cdClearStatusAndCallback();
         } else {
-            CdIntToPos(D_8008A3B8, D_8008A3D8.params);
+            CdIntToPos(D_8008A3B8, &D_8008A3D8.params);
             D_8008A3D8.status = 7;
         }
         break;
@@ -275,7 +276,7 @@ void func_80039218(void) {
             sndKeyOn(0x10, 0, 0x80, 0x7F, 0);
         }
         VSync(0);
-        CdIntToPos(D_8008A3B8, D_8008A3D8.params);
+        CdIntToPos(D_8008A3B8, &D_8008A3D8.params);
         D_8008A3D8.status = 7;
         CdFlush();
         CdControl(9, 0, 0);

--- a/src/cdread.c
+++ b/src/cdread.c
@@ -4,11 +4,8 @@
 #include "sound.h"
 #include "cd.h"
 
-extern CdDriveState D_8008A3C8;
-extern s32 D_8008A3B8;
-extern u8 D_8008A3DC[];
+/* D_8008A3C8 / D_8008A3B8 / D_8008A3DC / D_800853B8 come from cd.h. */
 extern u8 *D_80039418;
-extern u8 D_800853B8[];
 extern s32 D_80056558;
 
 typedef void (*CdHandler)(void);

--- a/src/cdrom.c
+++ b/src/cdrom.c
@@ -1,14 +1,10 @@
 #include "common.h"
 #include "psxsdk/libgpu.h"
+#include "psxsdk/libcd.h"
 #include "overlay.h"
 #include "cd.h"
 #include "cdrom.h"
 #include "snd_cd.h"
-
-/* CdIntToPos is a PsyQ SDK routine (psxsdk/libcd.h), but FF8 calls it with a
-   raw u8 position buffer rather than CdlLOC*; kept local until the libcd.h
-   signature is reconciled. */
-void CdIntToPos(s32 lba, u8 *pos);
 
 /**
  * @brief Detect the disc number by searching for disc-specific files.
@@ -124,7 +120,7 @@ void flushCdAndWait(void) {
 void func_80038760(s32 mode, s32 lba, u32 size, u8 *dest, void (*callback)(void)) {
     while (func_800393C8()) {}
 
-    CdIntToPos(lba, D_8008A3D8.params);
+    CdIntToPos(lba, &D_8008A3D8.params);
     D_8008A3D8.sectorCount = (size + 0x7FF) >> 11;
     D_8008A3D8.readBuffer = dest;
     D_8008A3D8.callback = callback;
@@ -303,7 +299,7 @@ void resetCdDriveMode(void) {
  * @return CD state code (see above), also stored in @c D_8008A3C8.state.
  */
 s32 func_80038A60(void) {
-    u8 loc[4];
+    CdlLOC loc;
     u8 result[8];
     s32 ready;
     s32 i;
@@ -368,8 +364,8 @@ s32 func_80038A60(void) {
         return 1;
     }
 
-    CdIntToPos(0x17, loc);
-    CdControlB(0x15, loc, result);
+    CdIntToPos(0x17, &loc);
+    CdControlB(0x15, (u8 *)&loc, result);
     if ((result[0] & 1) || (result[1] & 0x40)) {
         do { D_8008A3C8.state = 1; } while (0);
         return 1;

--- a/src/cdrom.c
+++ b/src/cdrom.c
@@ -2,24 +2,12 @@
 #include "psxsdk/libgpu.h"
 #include "overlay.h"
 #include "cd.h"
+#include "cdrom.h"
+#include "snd_cd.h"
 
-extern u8 D_8008A3DC[];
-extern CdDriveState D_8008A3C8;
-extern u8 D_8001092C[];
-extern u8 D_8001093C[];
-extern u8 D_8001094C[];
-extern u8 D_8001095C[];
-extern s16 D_8008A3D0;
-extern s8 D_8008A3DA;
-extern u16 D_8008A3D2;
-extern u8 D_8008A3D9;
-extern s32 D_8008A3B8;
-extern u8 D_800853B8[];
-
-s32 func_80039444(u8 *buf, u8 *dest);
-
-void resetCdDrive(void);
-void setDiscNumber(s32 a0);
+/* CdIntToPos is a PsyQ SDK routine (psxsdk/libcd.h), but FF8 calls it with a
+   raw u8 position buffer rather than CdlLOC*; kept local until the libcd.h
+   signature is reconciled. */
 void CdIntToPos(s32 lba, u8 *pos);
 
 /**
@@ -61,7 +49,7 @@ void setAudioVolume(s32 a0) {
 /**
  * @brief Initialize the CD-ROM subsystem.
  *
- * Clears CD state variables (D_8008A3D8, D_8008A3D0). If a0 is nonzero,
+ * Clears CD state variables (D_8008A3D8, D_8008A3C8.state). If a0 is nonzero,
  * spins until CdInit succeeds, disables CD debug output, sends a
  * CdControlB command (0xE = SetMode, double-speed 0x80), waits 3 vsyncs,
  * then reads the disc ID via detectDiscNumber and stores it.
@@ -75,7 +63,7 @@ void initCdSubsystem(s32 a0) {
 
     D_8008A3D8.flags = 0;
     D_8008A3D8.status = 0;
-    D_8008A3D0 = 0;
+    D_8008A3C8.state = 0;
 
     if (a0 != 0) {
         do { } while (!CdInit());
@@ -84,7 +72,7 @@ void initCdSubsystem(s32 a0) {
         CdControlB(0xE, &buf, 0);
         VSync(3);
         result = detectDiscNumber();
-        D_8008A3DA = result;
+        D_8008A3C8.discId = result;
         setDiscNumber((s8)result);
     }
 }
@@ -134,16 +122,13 @@ void flushCdAndWait(void) {
  * @param callback Completion callback (stored at callback/0x20, may be NULL).
  */
 void func_80038760(s32 mode, s32 lba, u32 size, u8 *dest, void (*callback)(void)) {
-    CdReadState *req;
-
     while (func_800393C8()) {}
 
-    CdIntToPos(lba, &D_8008A3DC[0]);
-    req = (CdReadState *)(&D_8008A3DC[0] - 4);
-    req->sectorCount = (size + 0x7FF) >> 11;
-    req->readBuffer = dest;
-    req->callback = callback;
-    req->status = mode;
+    CdIntToPos(lba, D_8008A3D8.params);
+    D_8008A3D8.sectorCount = (size + 0x7FF) >> 11;
+    D_8008A3D8.readBuffer = dest;
+    D_8008A3D8.callback = callback;
+    D_8008A3D8.status = mode;
     D_8008A3C8.timeout = 0;
 }
 
@@ -284,20 +269,20 @@ void resetCdDrive(void) {
  *
  * Sends CdControlB command 0xE (SetMode) with null parameters, waits
  * 3 VSync periods, sends command 0x8 (Pause), then marks the CD state
- * byte D_8008A3D9 as 0xB (complete).
+ * byte D_8008A3C8.cdState as 0xB (complete).
  */
 void resetCdDriveMode(void) {
     CdControlB(0xE, 0, 0);
     VSync(3);
     CdControlB(8, 0, 0);
-    D_8008A3D9 = 0xB;
+    D_8008A3C8.cdState = 0xB;
 }
 
 
 /**
  * @brief Verify the disc in the drive and classify its state.
  *
- * Polls the CD drive and writes a status code to the global @c D_8008A3D0,
+ * Polls the CD drive and writes a status code to the global @c D_8008A3C8.state,
  * which it also returns:
  *   - 0: valid FF8 data disc; disc number recorded in @c D_8008A3D8.discNum.
  *   - 1: error / unrecognized disc.
@@ -315,7 +300,7 @@ void resetCdDriveMode(void) {
  * "seeking" (@c CdDiskReady == 5) it periodically pulses @ref sndKeyOn as a
  * keep-alive and reports busy (2).
  *
- * @return CD state code (see above), also stored in @c D_8008A3D0.
+ * @return CD state code (see above), also stored in @c D_8008A3C8.state.
  */
 s32 func_80038A60(void) {
     u8 loc[4];
@@ -327,7 +312,7 @@ s32 func_80038A60(void) {
 
     CdControlB(1, 0, result);
     if (result[0] & 0x10) {
-        D_8008A3D0 = 3;
+        D_8008A3C8.state = 3;
         return 3;
     }
 
@@ -336,7 +321,7 @@ s32 func_80038A60(void) {
     do {
         VSync(0);
         if (--i == 0) {
-            D_8008A3D0 = 5;
+            D_8008A3C8.state = 5;
             return 5;
         }
         CdControlB(1, 0, result);
@@ -357,10 +342,10 @@ s32 func_80038A60(void) {
         D_8008A3C8.state = 2;
         return 2;
     case 0x10:
-        D_8008A3D0 = 3;
+        D_8008A3C8.state = 3;
         return 3;
     default:
-        D_8008A3D0 = 1;
+        D_8008A3C8.state = 1;
         return 1;
     }
 
@@ -368,25 +353,25 @@ s32 func_80038A60(void) {
     CdControlB(0xE, &mode, result);
     switch (CdGetDiskType()) {
     case 1:
-        D_8008A3D0 = 4;
+        D_8008A3C8.state = 4;
         return 4;
     case 0:
-        D_8008A3D0 = 5;
+        D_8008A3C8.state = 5;
         return 5;
     case 2:
         break;
     case 0x10:
-        D_8008A3D0 = 3;
+        D_8008A3C8.state = 3;
         return 3;
     default:
-        D_8008A3D0 = 1;
+        D_8008A3C8.state = 1;
         return 1;
     }
 
     CdIntToPos(0x17, loc);
     CdControlB(0x15, loc, result);
     if ((result[0] & 1) || (result[1] & 0x40)) {
-        do { D_8008A3D0 = 1; } while (0);
+        do { D_8008A3C8.state = 1; } while (0);
         return 1;
     }
     mode = 0x80;
@@ -395,39 +380,39 @@ s32 func_80038A60(void) {
     D_8008A3D8.status = 0;
     discNum = detectDiscNumber();
     if (discNum == -1) {
-        D_8008A3D0 = 6;
+        D_8008A3C8.state = 6;
         return 6;
     }
     D_8008A3D8.discNum = discNum;
-    D_8008A3D0 = 0;
+    D_8008A3C8.state = 0;
     return 0;
 }
 
 
 /**
  * @brief Get the current disc ID.
- * @return Disc identifier as a signed byte (D_8008A3DA).
+ * @return Disc identifier as a signed byte (D_8008A3C8.discId).
  */
 s8 getDiscId(void) {
-    return D_8008A3DA;
+    return D_8008A3C8.discId;
 }
 
 
 /**
  * @brief Set the current disc number.
- * @param a0 Disc number to store in D_8008A3D2.
+ * @param a0 Disc number to store in D_8008A3C8.discNumber.
  */
 void setDiscNumber(s32 a0) {
-    D_8008A3D2 = a0;
+    D_8008A3C8.discNumber = a0;
 }
 
 
 /**
  * @brief Get the current CD-ROM subsystem state.
- * @return CD state machine phase (D_8008A3D9).
+ * @return CD state machine phase (D_8008A3C8.cdState).
  */
 u32 getCdState(void) {
-    return D_8008A3D9;
+    return D_8008A3C8.cdState;
 }
 
 

--- a/src/intro.c
+++ b/src/intro.c
@@ -2,6 +2,7 @@
 #include "battle.h"
 #include "gamestate.h"
 #include "intro.h"
+#include "cdrom.h"
 #include "snd_init.h"
 #include "psxsdk/libgpu.h"
 #include "psxsdk/libetc.h"


### PR DESCRIPTION
- Flesh out cdrom.h (public + private cdrom.c interface) and add snd_cd.h for func_80039444; cdrom.c includes its own header.
- Move shared CD driver state (D_8008A3C8/DC/B8, D_800853B8) into cd.h and drop the duplicate externs from cdrom.c and cdread.c.
- Fold the standalone D_8008A3D0/D2/D9/DA symbols into CdDriveState fields (state/discNumber/cdState/discId); type discId as s8 and discNumber as s16.
- Replace func_80038760's (D_8008A3DC - 4) pointer hack with equivalent D_8008A3D8.params struct access (byte-identical, no magic offset).
- Move resetCdDriveMode/func_80038A60 prototypes from intro.h to their owner cdrom.h; intro.c includes cdrom.h.