### PR TITLE
battle: decompile func_80099D30 and add bc_object1 rodata split

### DIFF
--- a/config/battle.ovl.yaml
+++ b/config/battle.ovl.yaml
@@ -48,12 +48,11 @@ segments:
     start: 0x0
     vram: 0x80098000
     subsegments:
-      - [0x0, asm, bc_dispatch]
-      - { start: 0x18, type: .rodata, name: bc_object1, linker_section_order: .text }
+      - { start: 0x0, type: .rodata, name: bc_object1, linker_section_order: .text }
       - [0x30, asm, bc_dispatch_obf]
       - { start: 0x130, type: .rodata, name: bc_object2, linker_section_order: .text }
       - { start: 0xA84, type: rodata, name: bc_object2A84, linker_section_order: .text }
-      - [0x1FE8, c, bc_object1]
+      - [0x1D30, c, bc_object1]
       - [0x3AC4, c, bc_object2]
       - [0x98E0, c, bc_object3]
       - [0xE184, c, bc_object4]

--- a/config/symbol_addrs.battle.txt
+++ b/config/symbol_addrs.battle.txt
@@ -1467,5 +1467,5 @@ jtbl_80099C4C = 0x80099C4C; // type:jtbl size:0x38
 jtbl_80099C84 = 0x80099C84; // type:jtbl size:0x34
 jtbl_80099CB8 = 0x80099CB8; // type:jtbl size:0x1C
 jtbl_80099CD4 = 0x80099CD4; // type:jtbl size:0x2C
-jtbl_80099D00 = 0x80099D00; // type:jtbl size:0x2E8
+jtbl_80099D00 = 0x80099D00; // type:jtbl size:0x30
 g_fieldVars = 0x800562C4;

--- a/include/btl_color.h
+++ b/include/btl_color.h
@@ -30,7 +30,8 @@ extern u16  remapControllerInput(u16 bitmask);
 extern s32  remapButtonIndex(s32 index);
 extern s32  reverseButtonRemap(s32 index);
 extern void btlColorStub1044(void);
-extern void updatePaletteTransition(void);
+extern void func_800316D4(s32 arg0, s32 arg1, s32 arg2, s32 arg3);
+extern void updatePaletteTransition(s32 arg0, s32 arg1);
 extern s32  renderBattleString(s32 ot, s32 pkt, u8 *str, s32 y, s32 width, s32 color);
 extern void setTransitionPhase7(void);
 extern void setTransitionFlag(s32 val);
@@ -53,5 +54,9 @@ extern void flipBattleOtBuffer(void);
 
 s32 func_8002FF34(s32 renderCtx, s32 cursorY, s32 stringId, s32 x, s32 y, s32 color);
 s32 func_800300F8(s32 renderCtx, s32 x, s32 w, s32 y, s32 color, s32 menuColor, s32 selColor);
+s32 func_800302DC(s32 arg0, s32 arg1);
+s32 func_80031364(u32 *ot, s32 pkt);
+s32 func_80030A54(CmdStream *stream);
+s32 renderAnimOverlay(s32 arg0, s32 arg1);
 
 #endif

--- a/include/gamestate.h
+++ b/include/gamestate.h
@@ -461,8 +461,9 @@ extern u16 *D_800852F0;
 /* --- Save / GF / chocobo-world state setters --- */
 extern void setGfExists(s32 gfId);
 extern void clearEntityFlags(void);
+extern void func_800370AC(s32 arg0);
 extern void func_80038030(s32 mapAddr);
-extern void func_80038490(s32 descIndex, s32 dest);
+extern void func_80038490(u8 *src, u8 *dst);
 extern void enableChocoboWorld(void);
 
 /** @brief Resolve a character ID (e.g. party slot) to its global character code. */

--- a/src/battle/bc_object1.c
+++ b/src/battle/bc_object1.c
@@ -102,6 +102,86 @@ s32  func_8009B74C(s32, s32); /* also in field_engine */
 
 extern void func_800D0F74(void); /* defined in another battle TU */
 extern SoundCmd *func_800B8564(s32, s32); /* defined in bc_object9.c */
+extern u8 D_800EE38C[]; /* defined in the main binary */
+
+/* Forward declarations for callees defined later in this TU. */
+void func_8009A160(void);
+void func_8009A1E0(void);
+void func_80099FE8(void);
+void func_80099F18(void);
+void func_80099F58(void);
+void func_80099FA0(void);
+
+/**
+ * @brief Battle main loop driver.
+ *
+ * Resets the battle via @c func_80099FE8, then repeatedly dispatches on the
+ * battle state (@c D_800ED148.entities[0].state.word) until the split timer
+ * (@c D_800ED148.entities[0].timers.SplitTimer.timer) reaches zero. State 4
+ * runs the case-4 block: clears the entity animation group, sets @c unk5C3,
+ * rebuilds the three entity slots, applies status/flag cleanup and music
+ * calls, then resumes the state machine.
+ */
+void func_80099D30(void) {
+    void *var_s0;
+    s32 var_s1;
+
+    func_80099FE8();
+    while (D_800ED148.entities[0].timers.SplitTimer.timer != 0) {
+        switch (D_800ED148.entities[0].state.word) {
+        case 1:
+            func_8009A160();
+            break;
+        case 0:
+        case 2:
+            func_8009A308();
+            break;
+        case 3:
+            func_8009A1E0();
+            break;
+        case 4:
+            var_s1 = 0;
+            func_800DC664();
+            D_800ED148.unk5C3 = 1;
+            func_8009AB98();
+            func_8009AE9C();
+            var_s0 = D_800EE38C;
+            do {
+                func_800A5C48(var_s0);
+                var_s1 += 1;
+                var_s0 += 0x18;
+            } while (var_s1 < 3);
+            func_800A5BC4();
+            if (D_800ED148.unk12FE != 0) {
+                func_800A86F0(1);
+                func_800A86F0(2);
+                func_800A86F0(0);
+            }
+            if (D_800ED148.unk12FD == 0) {
+                func_800AD9C0();
+                func_800A63DC();
+            }
+            if ((D_800ED148.unk12EB != 0) && (D_800ED148.unk12FD == 0) && (D_800ED148.entities[0].stateMachine.unk0 == 0) && (D_80082C0F == 0)) {
+                func_800B0C08();
+                func_800B2038();
+            }
+            func_8009B478();
+            func_8009B520();
+            D_800ED148.unk5C3 = 0;
+            func_8009A308();
+            func_80099F18();
+            func_80099F58();
+            break;
+        }
+    }
+    func_800AF254();
+}
+
+INCLUDE_ASM("asm/ovl/battle/nonmatchings/bc_object1", func_80099F18);
+
+INCLUDE_ASM("asm/ovl/battle/nonmatchings/bc_object1", func_80099F58);
+
+INCLUDE_ASM("asm/ovl/battle/nonmatchings/bc_object1", func_80099FA0);
 
 /**
  * @brief Battle initialization entry point.

--- a/src/btl_color.c
+++ b/src/btl_color.c
@@ -4,6 +4,7 @@
 #include "battle.h"
 #include "btl_color.h"
 #include "gamestate.h"
+#include "numstr.h"
 
 /* --- Local type definitions --- */
 
@@ -36,6 +37,11 @@ typedef struct {
     u8 srcPalette;  /* 0x08 */
     u8 dstPalette;  /* 0x09 */
     u8 timer;       /* 0x0A */
+    u8 lineCount;   /* 0x0B */
+    u8 oldName[3];  /* 0x0C */
+    u8 newName[3];  /* 0x0F */
+    u8 oldName2[6]; /* 0x12 */
+    u8 newName2[6]; /* 0x18 */
 } PaletteTransition;
 
 /** @brief Battle HUD OT buffer (smaller display list for UI elements). */
@@ -61,6 +67,11 @@ extern BattleCameraState g_cameraShake; /* 0x800834D0 */
 extern s32 g_gpuColor;               /* 0x800834C8 — GPU color value */
 extern u16 g_cameraVibrateIntensity; /* 0x800834D4 — camera vibrate intensity */
 extern s32 g_battleTimer;               /* 0x80083750 — battle timer */
+extern u8 g_animCurveFadeOut[];         /* 0x800837B0 — 65-step fade curve */
+extern u8 D_80052A64[];
+extern s32 func_800432D8(void);
+extern void copyDisplayRect(RECT *dst);
+extern u8 *emitDrawEnvPackets(u8 *ot, u8 *pkt);
 
 /**
  * @brief Clear the RGB color fields of an SFX entry.
@@ -197,7 +208,79 @@ void updateCameraVibrate(void) {
  *
  * @see https://decomp.me/scratch/CEsOX
  */
-INCLUDE_ASM("asm/nonmatchings/btl_color", func_800302DC);
+s32 func_800302DC(s32 arg0, s32 arg1) {
+    u8 buf[24];
+    s32 out;
+    u32 color;
+    s32 timer;
+    BattleCameraState *shake;
+    s32 y;
+    s32 unk2;
+    s32 i;
+    s32 threshold;
+    s32 ret;
+    s32 c;
+
+    out = arg1;
+    ret = func_800432D8();
+
+    threshold = 0x1E;
+    if (ret == 1) {
+        threshold = 0x19;
+    }
+
+    shake = &g_cameraShake;
+    if ((u8)shake->enable == 0) {
+        return out;
+    }
+
+    color = (u16)shake->zoom;
+    y = (u16)g_cameraShake.intensity;
+    timer = g_gameState.mainData.countdownTimer;
+    unk2 = (u8)shake->direction;
+
+    color >>= 5;
+    color &= 0xFF;
+
+    {
+        u32 lo;
+        u32 hi;
+
+        lo = color | (color << 8);
+        hi = color << 16;
+        color = lo | hi;
+    }
+
+    color |= 0x64000000;
+    timer--;
+    timer = (timer < 0) ? 0 : ((timer >= 0x1798) ? 0x1797 : timer);
+
+    intToDecStringShort(timer / 60, buf, 0x70);
+
+    for (i = 3; i < 5; i++) {
+        c = buf[i];
+        if (i != 3 || c != 0x70) {
+            out = func_8002FF34(arg0, out, c, y, unk2, color);
+        }
+        y += 10;
+    }
+
+    y++;
+    if (shake->counter < threshold) {
+        out = func_8002FF34(arg0, out, 0x7A, y, unk2, color);
+    }
+
+    y += 7;
+    intToDecStringShort(timer % 60, buf, 0x70);
+
+    for (i = 3; i < 5; i++) {
+        c = buf[i];
+        out = func_8002FF34(arg0, out, c, y, unk2, color);
+        y += 10;
+    }
+
+    return (s32)emitDrawEnvPackets((u8 *)arg0, (u8 *)out);
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/btl_color", func_80030518);
@@ -422,7 +505,93 @@ s32 loadBattleCmd(u8 *data, s32 idx, s32 priority) {
  * @return Interpolated value (0-255), or -1 if stream ended.
  * @see https://decomp.me/scratch/oOOHt
  */
-INCLUDE_ASM("asm/nonmatchings/btl_color", func_80030A54);
+s32 func_80030A54(CmdStream *stream) {
+    u8 duration;
+    u8 *ptr;
+    u8 *end;
+
+    s32 cursor;
+    u16 cursor_u;
+
+    s32 val1;
+    s32 val2;
+    s32 steps;
+    s32 v1;
+
+    s32 cond;
+
+    if (!stream->enabled) {
+        return -1;
+    }
+
+    ptr = stream->start;
+    end = stream->end;
+
+    cursor = stream->cursor;
+    cursor_u = stream->cursor;
+
+    if (!(ptr < end)) {
+        stream->enabled = 0;
+        return -1;
+    }
+
+    duration = ptr[1];
+
+    /*
+     * This must be the same variable that later becomes ptr[0],
+     * so GCC keeps it in a1:
+     *
+     *   andi a1, v1, 0xFF
+     *   beq  a1, v0, ...
+     *   slt  v0, a3, a1
+     */
+    val1 = (u8)duration;
+
+    if (val1 == 0xFF) {
+        return -1;
+    }
+
+    cond = cursor < val1;
+
+    val1 = ptr[0];
+    val2 = ptr[2];
+
+    cursor++;
+
+    if (cond) {
+        goto interpolate;
+    }
+
+    val1 = val2;
+    stream->start = ptr + 2;
+    stream->cursor = 0;
+
+    goto clamp;
+
+interpolate:
+    steps = (u8)(duration + 1);
+
+    val1 = val1 * (steps - cursor);
+    val1 += val2 * cursor;
+    val1 /= steps;
+
+    stream->cursor = cursor_u + 1;
+
+clamp:
+    val1 <<= 1;
+
+    if (val1 >= 0) {
+        if (val1 < 0x100) {
+            v1 = val1;
+        } else {
+            v1 = 0xFF;
+        }
+    } else {
+        v1 = 0;
+    }
+
+    return v1;
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/btl_color", func_80030B2C);
@@ -673,7 +842,7 @@ void btlColorStub1044(void) {
  * State 7-8: fade in (ramp fade back down to 0 in steps of 0x100).
  * States 6, 9, 10: idle/complete.
  */
-void updatePaletteTransition(void) {
+void updatePaletteTransition(s32 arg0, s32 arg1) {
     u16 *state = &D_80083754.state;
     PaletteTransition *p = &D_80083754;
 
@@ -779,7 +948,165 @@ skip:
 INCLUDE_ASM("asm/nonmatchings/btl_color", func_80031224);
 
 
-INCLUDE_ASM("asm/nonmatchings/btl_color", func_80031364);
+/* --- Palette-transition math helpers ---
+ * The -50x/59x curve scalings and the 12x palette-offset multiply are pure
+ * shift/add chains in the retail build; kept as macros so each site reads
+ * like the original arithmetic. */
+
+#define MUL50_1(x) ((x) << 1)
+#define MUL50_2(x) (MUL50_1(x) + (x))
+#define MUL50_3(x) (MUL50_2(x) << 3)
+#define MUL50_4(x) (MUL50_3(x) + (x))
+#define MUL50(x)   (MUL50_4(x) << 1)
+
+#define MUL59_1(x) ((x) << 4)
+#define MUL59_2(x) (MUL59_1(x) - (x))
+#define MUL59_3(x) (MUL59_2(x) << 2)
+#define MUL59(x)   (MUL59_3(x) - (x))
+
+#define MUL12(x) ((((x) << 1) + (x)) << 2)
+
+/* addPrim variant that takes the link temp as an ordinary "+r" operand.
+ * The retail site first reloads the spilled pkt pointer with
+ * `lw $t0, 0x28($sp)`; the "+r" operand forces that reload immediately
+ * before the asm (a bare-register addPrimFast cannot reproduce it).
+ *
+ * NOTE: this must be a plain compound statement, NOT `do { } while (0)`.
+ * gcc 2.7.2 leaves NOTE_INSN_LOOP_* notes from the do/while wrapper; the
+ * first insn after the LOOP_END note then gets reg_pending_sets_all in the
+ * scheduler, which fabricates a data dependency on the following
+ * `lbu p->lineCount` and pulls it ahead of the argument moves
+ * (yielding `lbu,a0,a1,...` instead of the retail `a0,a1,lbu,...`). */
+#define addPrimFastTmp(ot, p, tmp) {                    \
+    __asm__ __volatile__(                                \
+        ".set push\n"                                    \
+        ".set noat\n"                                    \
+        "sll $at, %1, 8\n"                               \
+        "lwl %0, 2(%2)\n"                                \
+        "swl $at, 2(%2)\n"                               \
+        "swl %0, 2(%1)\n"                                \
+        ".set pop\n"                                     \
+        : "+r" (tmp)                                     \
+        : "r"(p), "r"(ot)                                \
+        : "at", "memory");                               \
+}
+
+extern s32 func_80031224(u32 *ot, s32 pkt, s32 y, s32 height);
+
+
+/**
+ * Render the two-line palette-transition label.
+ *
+ * Byte-matches the retail build (gcc 2.7.2-970404, -O2 -G0, PsyQ 4.1) up
+ * to linker-resolved j/jal/lui-addiu constant fakes. The addPrim packet
+ * link uses the temp-operand idiom above, matching the retail
+ * `lw $t0, 0x28($sp)` reload before the lwl/swl splice.
+ */
+s32 func_80031364(u32 *ot, s32 pkt) {
+    RECT rect;
+    u8 *pkt_r;
+    PaletteTransition *p;
+    u32 color;
+    s32 xPos;
+    s32 curve;
+    s32 brightness;
+    s32 absDir;
+    s32 y;
+    s32 calc_val;
+    s32 yBotQuot;
+    s32 temp;
+    s32 yOff;
+    s32 pkt_tmp;
+    s32 next;
+    s32 s0;
+
+    pkt_r = (u8 *)pkt;
+    p = &D_80083754;
+
+    if (p->fade <= 0) {
+        return (s32)pkt_r;
+    }
+
+    copyDisplayRect(&rect);
+
+    {
+        color = *(u16 *)((u8 *)p - 0x280);
+        color >>= 5;
+        color &= 0xFF;
+        color = (color | (color << 8)) | (color << 16);
+        color |= 0x64000000;
+    }
+
+    curve = 0x1000 - p->fade;
+
+    curve = g_animCurveFadeOut[curve / 64];
+
+    brightness = p->brightness;
+
+    curve <<= 6;
+
+    if (p->srcPalette < p->dstPalette) {
+        absDir = -brightness;
+        yOff = 12;
+    } else {
+        absDir = brightness;
+        yOff = -12;
+    }
+
+    calc_val = -MUL50(curve);
+    xPos = 0xC4;
+
+    if (calc_val < 0) {
+        calc_val += 0xFFF;
+    }
+
+    s0 = calc_val >> 12;
+    temp = s0 + 0x10;
+
+    pkt_r = (u8 *)func_8002FF34((s32)ot, (s32)pkt_r, 0xB0, temp, xPos, color);
+
+    y = s0 + 0x30;
+
+    if (brightness == 0) {
+        pkt_r = (u8 *)renderBattleString((s32)ot, (s32)pkt_r, p->newName, y, xPos, color);
+    } else if (brightness == 0x1000) {
+        pkt_r = (u8 *)renderBattleString((s32)ot, (s32)pkt_r, p->oldName, y, xPos, color);
+    } else {
+        xPos = MUL12(absDir) / 4096 + 0xC4;
+
+        next = renderBattleString((s32)ot, (s32)pkt_r, p->newName, y, xPos, color);
+        pkt_r = (u8 *)renderBattleString((s32)ot, next, p->oldName, y, xPos + yOff, color);
+    }
+
+    xPos = 0xC4;
+
+    yBotQuot = MUL59(curve) / 4096;
+    y = yBotQuot + 0xF0;
+
+    pkt_r = (u8 *)func_8002FF34((s32)ot, (s32)pkt_r, 0xB1, yBotQuot + 0x11D, xPos, color);
+
+    if (brightness == 0) {
+        pkt_r = (u8 *)renderBattleString((s32)ot, (s32)pkt_r, p->newName2, y, xPos, color);
+    } else if (brightness == 0x1000) {
+        pkt_r = (u8 *)renderBattleString((s32)ot, (s32)pkt_r, p->oldName2, y, xPos, color);
+    } else {
+        xPos = MUL12(absDir) / 4096 + 0xC4;
+
+        next = renderBattleString((s32)ot, (s32)pkt_r, p->newName2, y, xPos, color);
+        pkt_r = (u8 *)renderBattleString((s32)ot, next, p->oldName2, y, xPos + yOff, color);
+    }
+
+    rect.h = 12;
+    rect.y += 0xC4;
+
+    SetDrawArea((DR_AREA *)pkt_r, &rect);
+
+    addPrimFastTmp(ot, pkt_r, pkt_tmp);
+
+    temp = func_80031224(ot, (s32)pkt_r + 0xC, temp, y + p->lineCount * 9);
+
+    return (s32)emitDrawEnvPackets((u8 *)ot, (u8 *)temp);
+}
 
 
 /** @brief Begin the fade-out phase of the palette transition. */
@@ -788,7 +1115,85 @@ void setTransitionPhase7(void) {
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/btl_color", func_800316D4);
+void func_800316D4(s32 arg0, s32 arg1, s32 arg2, s32 arg3)
+{
+    u8 buf[16];
+    PaletteTransition *d;
+    s32 r_arg3;
+    u8 *buf5;
+    s32 limit;
+    s32 seven;
+    s32 i;
+
+    D_80083754.state = 0;
+    d = &D_80083754;
+    r_arg3 = arg3;
+    d->brightness = 0;
+    d->fade = 0;
+    d->timer = 0;
+    d->srcPalette = arg0;
+    d->dstPalette = arg1;
+
+    buf5 = &buf[5];
+
+    intToDecString(arg2, buf, 0x60);
+    copyString(d->newName2, buf5);
+    replaceLeadingZeros(d->newName2, 4, 0x60, 7);
+
+    intToDecString(r_arg3, buf, 0x60);
+    copyString(d->oldName2, buf5);
+    replaceLeadingZeros(d->oldName2, 4, 0x60, 7);
+
+    if (arg0 < 0x1F)
+    {
+        intToDecStringShort(arg0, buf, 0x60);
+        copyString(d->newName, &buf[3]);
+        replaceLeadingZeros(d->newName, 1, 0x60, 7);
+    }
+    else
+    {
+        copyString(d->newName, D_80052A64);
+    }
+
+    if (arg1 < 0x1F)
+    {
+        intToDecStringShort(arg1, buf, 0x60);
+        copyString(d->oldName, &buf[3]);
+        replaceLeadingZeros(d->oldName, 1, 0x60, 7);
+    }
+    else
+    {
+        copyString(d->oldName, D_80052A64);
+    }
+
+    i = 0;
+    limit = 5;
+    seven = 7;
+
+    for (; i < 5; i++)
+    {
+        if (d->oldName2[i] != seven && i < limit)
+        {
+            limit = i;
+            break;
+        }
+    }
+
+    i = 0;
+    seven = 7;
+
+    for (; i < 5; i++)
+    {
+        if (d->newName2[i] != seven && i < limit)
+        {
+            limit = i;
+            break;
+        }
+    }
+
+    d->lineCount = limit;
+    updatePaletteTransition(limit, seven);
+}
 
 
 /** @brief Set the palette transition flag. */
@@ -888,7 +1293,26 @@ INCLUDE_ASM("asm/nonmatchings/btl_color", func_80031A18);
  * @param pkt Packet buffer pointer.
  * @return Updated packet pointer.
  */
-INCLUDE_ASM("asm/nonmatchings/btl_color", renderAnimOverlay);
+s32 renderAnimOverlay(s32 arg0, s32 arg1)
+{
+    s32 overlay = arg0;
+    s32 ret = arg1;
+    s32 i = 0;
+    u32 packed = g_cameraVibrateIntensity;
+
+    u32 t = packed >> 5;
+    u32 hi = t << 16;
+    u32 lo = (t << 8) | 0x64000000;
+
+    packed = (hi | lo) | t;
+
+    do {
+        ret = func_80031A18(overlay, ret, i, packed);
+        i += 1;
+    } while (i < 2);
+
+    return ret;
+}
 
 
 /**
@@ -1076,5 +1500,4 @@ INCLUDE_ASM("asm/nonmatchings/btl_color", func_800320BC);
 
 
 INCLUDE_ASM("asm/nonmatchings/btl_color", renderBattleFrame);
-
 

--- a/src/btl_entity.c
+++ b/src/btl_entity.c
@@ -15,7 +15,14 @@ extern s32 reverseButtonRemap(s32 index);
 INCLUDE_ASM("asm/nonmatchings/btl_entity", func_8002BAA0);
 
 
-INCLUDE_ASM("asm/nonmatchings/btl_entity", func_8002BC10);
+u32 func_8002BC10(u32 arg0, u32 arg1, u32 arg2, u32 arg3)
+{
+    u32 hi;
+
+    hi = func_8002B3A0(arg0, arg1, arg2, arg3, 3);
+
+    return __udivdi3(arg0, hi, arg2, arg3);
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/btl_entity", func_8002BC6C);

--- a/src/entity.c
+++ b/src/entity.c
@@ -2,7 +2,48 @@
 #include "psxsdk/libgpu.h"
 #include "battle.h"
 
-INCLUDE_ASM("asm/nonmatchings/entity", func_8003228C);
+void func_8003228C(s32 arg0, u8 *arg1)
+{
+    u8 *src;
+    u8 *dst;
+    s32 cond;
+    u8 c;
+
+    dst = arg1;
+    cond = arg0 & 0x100;
+
+    if (cond) {
+        src = getMenuString(0x6E);
+
+        while (1) {
+            c = *src;
+            src++;
+
+            if (c == 0xA) {
+                src++;
+                {
+                    u8 *src2 = func_80023A54(arg0 & 0xFF);
+                    u8 c2;
+
+                    while (1) {
+                        c2 = *src2;
+                        src2++;
+                        if (c2 == 0) break;
+                        *dst = c2;
+                        dst++;
+                    }
+                }
+            } else {
+                *dst = c;
+                dst++;
+            }
+
+            if (c == 0) break;
+        }
+    } else {
+        copyString(dst, getStatName(arg0));
+    }
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/entity", func_80032350);

--- a/src/gamestate.c
+++ b/src/gamestate.c
@@ -16,8 +16,56 @@ extern s32 D_80085220;
 extern u8 D_8005644B[];
 extern u16 D_800562C8[];
 extern s32 D_800562D4;
+extern u8 D_80077EBC;
+extern u16 D_80082C0A;
+extern u16 D_8005F11C;
+extern s32 findNthSetBit(s32, s32, u8 *, s32);
+extern s32 func_80021300(void);
 
-INCLUDE_ASM("asm/nonmatchings/gamestate", func_800370AC);
+void func_800370AC(s32 arg0)
+{
+    u8 *ptr;
+    u8 *base;
+    s32 mask;
+    s32 i;
+    s32 val;
+    s32 found;
+    s32 one;
+    s32 zero;
+    zero = 0;
+    if (arg0 < 0x21) {
+        ptr = &D_80077EBC;
+        base = ptr - 0x20;
+        mask = 0;
+        i = 0;
+        one = 1;
+        do {
+            val = *ptr++;
+            if (*ptr++ == 0) {
+                val = 0;
+            }
+            if (val != 0 && val < 0x21) {
+                if (arg0 == val) {
+                    return;
+                }
+                mask |= (one << base[val - 1]);
+            }
+            i++;
+        } while (i < 0xC6);
+        found = findNthSetBit(~mask, zero, ptr, one);
+        arg0 -= 1;
+        i = 0;
+        do {
+            if (found == base[i]) {
+                u8 tmp = base[arg0];
+                base[arg0] = found;
+                base[i] = tmp;
+                return;
+            }
+            i++;
+        } while (i < 0x20);
+    }
+}
 
 
 /**
@@ -98,7 +146,185 @@ void enableChocoboWorld(void) {
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/gamestate", func_80037308);
+extern u8 *getCharName(CharacterId charId);
+extern u8 g_characters[];
+
+void func_80037308(void *arg0, void *arg1)
+{
+    u8 buffer[0x490];
+
+    u8 *s6;
+    u8 *s4;
+    s32 s2;
+    s32 s3;
+    u8 *s5;
+    u8 *s1;
+    u8 *s0;
+    u8 *p;
+    u8 *gs_ptr;
+    s32 a2;
+    u8 *buf_ptr;
+    u8 *char_base;
+    u8 *name;
+    u32 c;
+    s32 w;
+    s32 y;
+    s32 x;
+    u8 *src;
+    u8 *dst_ptr;
+    s32 row;
+    s32 col;
+    u8 b;
+    u8 *sp;
+    u8 *new_var;
+    u8 *dp;
+    u8 high;
+    u8 low;
+
+    s6 = (u8 *)arg0;
+    s4 = (u8 *)arg1;
+    p = s4;
+
+    for (s3 = 0x8FF; s3 >= 0; s3--)
+    {
+        *(p++) = 0;
+    }
+
+    s3 = 0;
+
+    while (s3 < 3)
+    {
+        buf_ptr = (new_var = buffer);
+        s1 = new_var + 0xC;
+
+        gs_ptr = (u8 *)&g_gameState + s3;
+        a2 = gs_ptr[0xAF4];
+
+        if (a2 == 0xFF)
+        {
+            s3++;
+            s4 += 0x300;
+            continue;
+        }
+
+        s2 = 0;
+        s0 = s6;
+        s5 = s0 + (*((s32 *)s0));
+        s0 = s0 + (*((s32 *)(((u8 *)s0) + 4)));
+        s0 = s0 + 8;
+        s0 = s0 + (*((s32 *)s0));
+        s0 = s0 + 0xC;
+
+        col = 0x48B;
+        while (col >= 0)
+        {
+            *(buf_ptr++) = 0;
+            col--;
+        }
+
+        char_base = g_characters;
+        char_base += a2 * 152;
+
+        name = getCharName(char_base[8]);
+
+        while (1)
+        {
+            c = *(name++);
+
+            if (c == 0)
+            {
+                break;
+            }
+
+            if (c < 0x20)
+            {
+                c -= 0x19;
+                c = ((c << 3) - c) << 5;
+                c += *(name++);
+            }
+
+            c -= 0x20;
+
+            w = s5[c >> 1];
+
+            x++;
+            x--;
+
+            if (c & 1)
+            {
+                w >>= 4;
+            }
+
+            w &= 0xF;
+
+            if (w != 0)
+            {
+                w--;
+            }
+
+            dst_ptr = s1;
+            row = 12;
+
+            x = c / 21;
+            y = x;
+            x = c - (y * 21);
+
+            c = (y * 3) * 512;
+            y = x * 6;
+
+            src = (s0 + y) + c;
+
+            for (; row > 0; row--)
+            {
+                for (col = 6; col > 0; col--)
+                {
+                    b = *(src++);
+
+                    *dst_ptr |= b & 0xF;
+                    dst_ptr++;
+
+                    *dst_ptr |= b >> 4;
+                    dst_ptr++;
+                }
+
+                dst_ptr += 0x54;
+                src += 0x7A;
+            }
+
+            s1 += w;
+            s2 += w;
+        }
+
+        s0 = s4 + 0x30;
+        s1 += 1;
+        s2 = (s2 + 2) / 2;
+
+        for (row = 12; row > 0; row--)
+        {
+            sp = s1;
+            col = s2;
+            dp = s0;
+            s2 = col;
+
+            if (s2 > 0)
+            {
+                do
+                {
+                    high = *(--sp);
+                    low = *(--sp);
+                    *(--dp) = (low & 0xF) | (high << 4);
+                }
+                while ((--col) > 0);
+            }
+
+            s1 += 0x60;
+            s0 += 0x30;
+        }
+
+        s3++;
+        s4 += 0x300;
+    }
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/gamestate", func_800375A0);
@@ -134,7 +360,40 @@ void drawSaveIconWithArgs(s32 a0, s32 a1, s32 a2, s32 a3, s32 arg4, s32 arg5) {
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/gamestate", func_800377B4);
+u16 func_800377B4(s32 len, u8 *buf)
+{
+    u16 table[256];
+    u32 crc;
+    u32 i;
+    u32 val;
+    u32 j;
+    s32 ci;
+    ci = 0xFF;
+    do { table[ci] = 0; ci--; } while (ci >= 0);
+    crc = 0xFFFF;
+    i = 0;
+    do {
+        val = i << 8;
+        j = 0;
+        do {
+            if (val & 0x8000) val = (val << 1) ^ 0x1021;
+            else val <<= 1;
+            j++;
+            table[i] = val;
+        } while (j < 8);
+        i++;
+    } while (i < 0xFF);
+    if (len > 0) {
+        do {
+            u32 idx;
+            idx = *buf++;
+            len--;
+            idx ^= (crc & 0xFFFF) >> 8;
+            crc = table[idx] ^ (crc << 8);
+        } while (len > 0);
+    }
+    return ~crc & 0xFFFF;
+}
 
 
 /**
@@ -234,7 +493,33 @@ void mcFillFF(u8 *buf) {
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/gamestate", func_800379AC);
+s32 func_800379AC(void *arg0)
+{
+    u8 buffer[0x80];
+    s32 i;
+    if (pollCardReady() != 2)
+        return 0;
+    mcFillFF(buffer);
+    if (!writeCardBlock(arg0, buffer, 0))
+        return 0;
+    mcInitDirUsed(buffer);
+    for (i = 0; i < 0xF; i++)
+        if (!writeCardBlock(arg0, buffer, i + 1))
+            return 0;
+    mcInitDirFree(buffer);
+    for (i = 0; i < 0x14; i++)
+        if (!writeCardBlock(arg0, buffer, i + 0x10))
+            return 0;
+    mcFillFF(buffer);
+    for (i = 0; i < 0x1C; i++)
+        if (!writeCardBlock(arg0, buffer, i + 0x24))
+            return 0;
+    mcInitHeader(buffer);
+    if (!writeCardBlock(arg0, buffer, 0))
+        return 0;
+    markCardBusy(arg0);
+    return 1;
+}
 
 
 /** @brief Sets global D_80085218 to 1. */
@@ -412,7 +697,47 @@ void loadSoundBankB(void) {
 INCLUDE_ASM("asm/nonmatchings/gamestate", func_80037FB0);
 
 
-INCLUDE_ASM("asm/nonmatchings/gamestate", func_80038030);
+void func_80038030(s32 arg0) {
+    u8 *ptr = D_800780D8;
+
+    if (!(D_80082C0A & 0x10)) {
+        while (sndGetStatus() == 2) {
+            func_800393C8();
+        }
+
+        if (*(s32 *)(ptr + 0x6C) == -1) {
+            sndCmd11(0);
+        }
+
+        sndCmd40();
+        D_80085220 = arg0;
+        func_80037FB0(0, *(s8 *)(ptr + 0xCB), arg0);
+
+        if (*(u8 *)(ptr + 0xD6) == 0) {
+            do {
+                func_800393C8();
+            } while (*(u8 *)(ptr + 0xD6) == 0);
+        }
+
+        D_8005F11C = sndCmd10(toggleSoundBank());
+        sndCmdC0(0, 0x7F);
+    }
+
+    D_80082C11 = *(u8 *)(ptr + 0xC9) ^ 1;
+    sndStopPlayback();
+    sndCmdF1();
+    sndSetMasterVolume(0x7F);
+
+    if (func_80021300() == 0) {
+        sndPlaySfx(0xA, 0, 0x80, 0x7F);
+        sndPlaySfx(0xB, 0, 0x80, 0x7F);
+        sndPlaySfx(0xC, 0, 0x80, 0x7F);
+    } else {
+        sndPlaySfx(0x84, 0, 0x80, 0x7F);
+        sndPlaySfx(0x85, 0, 0x80, 0x7F);
+        sndPlaySfx(0x86, 0, 0x80, 0x7F);
+    }
+}
 
 
 /**
@@ -530,6 +855,84 @@ s32 fieldRandom(void) {
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/gamestate", func_80038490);
+extern u8 *D_80039418;
+#define D_80039440 (*(s32 *)((u8 *)&D_80039418 + 0x28))
+
+void func_80038490(u8 *src, u8 *dst)
+{
+  u8 *src_ptr;
+  u8 *dst_start;
+  s32 bit_cnt;
+  s32 flags;
+  u8 *src_end;
+  u8 *dst_end;
+  int new_var;
+  u8 *copy_src;
+  s32 offset;
+  u8 *new_var2;
+  s32 temp;
+  s32 v0;
+  src_ptr = src;
+  bit_cnt = 0;
+  flags = bit_cnt;
+  dst_start = dst;
+  D_80039440 = 0;
+  src_end = (src_ptr + (*((s32 *) src_ptr))) + 4;
+  src_ptr += 4;
+  new_var2 = dst_start;
+  while (1)
+  {
+    if (bit_cnt == 0)
+    {
+      if (src_ptr >= src_end)
+      {
+        return;
+      }
+      bit_cnt = 8;
+      flags = *(src_ptr++);
+    }
+    if (flags & 1)
+    {
+      if (src_ptr >= src_end)
+      {
+        return;
+      }
+      *(dst++) = *(src_ptr++);
+      D_80039440++;
+    }
+    else
+    {
+      if (src_ptr >= src_end)
+      {
+        return;
+      }
+      new_var = (dst - new_var2) + 0xFEE;
+      offset = *(src_ptr++);
+      temp = *(src_ptr++);
+      offset |= (temp & 0xF0) << 4;
+      v0 = (new_var - offset) & 0xFFF;
+      copy_src = dst - v0;
+      dst_end = (dst + (temp & 0x0F)) + 3;
+      if (copy_src < new_var2)
+      {
+        do
+        {
+          *(dst++) = 0;
+          copy_src++;
+        }
+        while (copy_src < new_var2);
+      }
+      while (dst < dst_end)
+      {
+        *(dst++) = *(copy_src++);
+        D_80039440++;
+      }
+
+    }
+    flags >>= 1;
+    bit_cnt--;
+  }
+
+}
 
 

--- a/src/render.c
+++ b/src/render.c
@@ -126,10 +126,40 @@ s32 getBitRank(s32 a0, s32 a1) {
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/render", func_80035B28);
+s32 func_80035B28(s32 arg0, s32 arg1) {
+    s32 index = arg1;
+    s32 mask = 1;
+
+    do {
+        index++;
+        if (index >= 0x20) {
+            index = 0;
+        }
+        if (index == arg1) {
+            return arg1;
+        }
+    } while ((arg0 & (mask << index)) == 0);
+
+    return index;
+}
 
 
-INCLUDE_ASM("asm/nonmatchings/render", func_80035B70);
+s32 func_80035B70(s32 arg0, s32 arg1) {
+    s32 index = arg1;
+    s32 mask = 1;
+
+    do {
+        index--;
+        if (index < 0) {
+            index = 0x1F;
+        }
+        if (index == arg1) {
+            return arg1;
+        }
+    } while ((arg0 & (mask << index)) == 0);
+
+    return index;
+}
 
 
 /** @brief Stores a word to global D_80083798. */

--- a/src/snd_note.c
+++ b/src/snd_note.c
@@ -22,7 +22,38 @@ INCLUDE_ASM("asm/nonmatchings/snd_note", func_8001A674);
 
 INCLUDE_ASM("asm/nonmatchings/snd_note", func_8001AA28);
 
-INCLUDE_ASM("asm/nonmatchings/snd_note", func_8001ACCC);
+typedef struct {
+    s32 unk00;
+    s32 unk04;
+    s32 unk08;
+} UnkStruct80074F10;
+
+extern UnkStruct80074F10 D_80074F10;
+extern void func_80017D14(void *arg0, s32 arg1);
+
+void func_8001ACCC(void *arg0, s32 arg1) {
+    s32 savedUnk04;
+    s32 newVal;
+
+    if (D_80074F10.unk08 != 0) {
+        if (--D_80074F10.unk08 == 0) {
+            savedUnk04 = *(s32 *)((u8 *)arg0 + 0x04);
+            *(s16 *)((u8 *)arg0 + 0x5E) = 0;
+            *(s32 *)((u8 *)arg0 + 0x04) = 0;
+            *(s32 *)((u8 *)arg0 + 0x10) = 0;
+            *(s32 *)((u8 *)arg0 + 0x14) = 0;
+            *(s32 *)((u8 *)arg0 + 0x18) = savedUnk04;
+        } else {
+            newVal = D_80074F10.unk00 + D_80074F10.unk04;
+
+            if ((newVal & 0xFFFF0000) != (D_80074F10.unk00 & 0xFFFF0000)) {
+                func_80017D14(arg0, arg1);
+            }
+
+            D_80074F10.unk00 = newVal;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/snd_note", func_8001AD60);
 


### PR DESCRIPTION
Decompiles `func_80099D30` (battle state-machine driver) to pure C.

This requires the battle overlay's bc_object1 jump table to sit at the
overlay base (0x0), so the split config is updated alongside:

- `config/battle.ovl.yaml`: move `bc_object1` `.rodata` to overlay
  base 0x0, shift the C segment `0x1FE8` → `0x1D30`.
- `config/symbol_addrs.battle.txt`: fix `jtbl_80099D00` size
  `0x2E8` → `0x30`.

The compiler-generated switch table is placed at `jtbl_80098000` via
`linker_section_order: .text`. Battle overlay verifies byte-exact
(`make verify-battle` MATCH).