### PR TITLE
battle: decompile func_80099D30 and add bc_object1 rodata split

### DIFF
--- a/config/battle.ovl.yaml
+++ b/config/battle.ovl.yaml
@@ -48,12 +48,11 @@ segments:
     start: 0x0
     vram: 0x80098000
     subsegments:
-      - [0x0, asm, bc_dispatch]
-      - { start: 0x18, type: .rodata, name: bc_object1, linker_section_order: .text }
+      - { start: 0x0, type: .rodata, name: bc_object1, linker_section_order: .text }
       - [0x30, asm, bc_dispatch_obf]
       - { start: 0x130, type: .rodata, name: bc_object2, linker_section_order: .text }
       - { start: 0xA84, type: rodata, name: bc_object2A84, linker_section_order: .text }
-      - [0x1FE8, c, bc_object1]
+      - [0x1D30, c, bc_object1]
       - [0x3AC4, c, bc_object2]
       - [0x98E0, c, bc_object3]
       - [0xE184, c, bc_object4]

--- a/config/symbol_addrs.battle.txt
+++ b/config/symbol_addrs.battle.txt
@@ -1467,5 +1467,5 @@ jtbl_80099C4C = 0x80099C4C; // type:jtbl size:0x38
 jtbl_80099C84 = 0x80099C84; // type:jtbl size:0x34
 jtbl_80099CB8 = 0x80099CB8; // type:jtbl size:0x1C
 jtbl_80099CD4 = 0x80099CD4; // type:jtbl size:0x2C
-jtbl_80099D00 = 0x80099D00; // type:jtbl size:0x2E8
+jtbl_80099D00 = 0x80099D00; // type:jtbl size:0x30
 g_fieldVars = 0x800562C4;

--- a/src/battle/bc_object1.c
+++ b/src/battle/bc_object1.c
@@ -102,6 +102,86 @@ s32  func_8009B74C(s32, s32); /* also in field_engine */
 
 extern void func_800D0F74(void); /* defined in another battle TU */
 extern SoundCmd *func_800B8564(s32, s32); /* defined in bc_object9.c */
+extern u8 D_800EE38C[]; /* defined in the main binary */
+
+/* Forward declarations for callees defined later in this TU. */
+void func_8009A160(void);
+void func_8009A1E0(void);
+void func_80099FE8(void);
+void func_80099F18(void);
+void func_80099F58(void);
+void func_80099FA0(void);
+
+/**
+ * @brief Battle main loop driver.
+ *
+ * Resets the battle via @c func_80099FE8, then repeatedly dispatches on the
+ * battle state (@c D_800ED148.entities[0].state.word) until the split timer
+ * (@c D_800ED148.entities[0].timers.SplitTimer.timer) reaches zero. State 4
+ * runs the case-4 block: clears the entity animation group, sets @c unk5C3,
+ * rebuilds the three entity slots, applies status/flag cleanup and music
+ * calls, then resumes the state machine.
+ */
+void func_80099D30(void) {
+    void *var_s0;
+    s32 var_s1;
+
+    func_80099FE8();
+    while (D_800ED148.entities[0].timers.SplitTimer.timer != 0) {
+        switch (D_800ED148.entities[0].state.word) {
+        case 1:
+            func_8009A160();
+            break;
+        case 0:
+        case 2:
+            func_8009A308();
+            break;
+        case 3:
+            func_8009A1E0();
+            break;
+        case 4:
+            var_s1 = 0;
+            func_800DC664();
+            D_800ED148.unk5C3 = 1;
+            func_8009AB98();
+            func_8009AE9C();
+            var_s0 = D_800EE38C;
+            do {
+                func_800A5C48(var_s0);
+                var_s1 += 1;
+                var_s0 += 0x18;
+            } while (var_s1 < 3);
+            func_800A5BC4();
+            if (D_800ED148.unk12FE != 0) {
+                func_800A86F0(1);
+                func_800A86F0(2);
+                func_800A86F0(0);
+            }
+            if (D_800ED148.unk12FD == 0) {
+                func_800AD9C0();
+                func_800A63DC();
+            }
+            if ((D_800ED148.unk12EB != 0) && (D_800ED148.unk12FD == 0) && (D_800ED148.entities[0].stateMachine.unk0 == 0) && (D_80082C0F == 0)) {
+                func_800B0C08();
+                func_800B2038();
+            }
+            func_8009B478();
+            func_8009B520();
+            D_800ED148.unk5C3 = 0;
+            func_8009A308();
+            func_80099F18();
+            func_80099F58();
+            break;
+        }
+    }
+    func_800AF254();
+}
+
+INCLUDE_ASM("asm/ovl/battle/nonmatchings/bc_object1", func_80099F18);
+
+INCLUDE_ASM("asm/ovl/battle/nonmatchings/bc_object1", func_80099F58);
+
+INCLUDE_ASM("asm/ovl/battle/nonmatchings/bc_object1", func_80099FA0);
 
 /**
  * @brief Battle initialization entry point.


### PR DESCRIPTION
Decompiles `func_80099D30` (battle state-machine driver) to pure C.

This requires the battle overlay's bc_object1 jump table to sit at the
overlay base (0x0), so the split config is updated alongside:

- `config/battle.ovl.yaml`: move `bc_object1` `.rodata` to overlay
  base 0x0, shift the C segment `0x1FE8` → `0x1D30`.
- `config/symbol_addrs.battle.txt`: fix `jtbl_80099D00` size
  `0x2E8` → `0x30`.

The compiler-generated switch table is placed at `jtbl_80098000` via
`linker_section_order: .text`. Battle overlay verifies byte-exact
(`make verify-battle` MATCH).